### PR TITLE
Scrape crio logs, includes kata logs too

### DIFF
--- a/clr-k8s-examples/3-efk/fluentd-es-configmap.yaml
+++ b/clr-k8s-examples/3-efk/fluentd-es-configmap.yaml
@@ -320,7 +320,7 @@ data:
     <source>
       @id journald-container-runtime
       @type systemd
-      matches [{ "_SYSTEMD_UNIT": "{{ container_runtime }}.service" }]
+      matches [{ "_SYSTEMD_UNIT": "crio.service" }]
       <storage>
         @type local
         persistent true
@@ -330,16 +330,16 @@ data:
       tag container-runtime
     </source>
 
-    <source>
-      @type systemd
-      path /var/log/journal
-      matches [{"SYSLOG_IDENTIFIER": "kata-runtime"}, {"SYSLOG_IDENTIFIER": "kata-proxy"}, {"SYSLOG_IDENTIFIER": "kata-shim"}]
-      tag kata-containers
-      <entry>
-        fields_strip_underscores true
-        fields_lowercase true
-      </entry>
-    </source>
+    # <source>
+    #   @type systemd
+    #   path /var/log/journal
+    #   matches [{"SYSLOG_IDENTIFIER": "kata-runtime"}, {"SYSLOG_IDENTIFIER": "kata-proxy"}, {"SYSLOG_IDENTIFIER": "kata-shim"}]
+    #   tag kata-containers
+    #   <entry>
+    #     fields_strip_underscores true
+    #     fields_lowercase true
+    #   </entry>
+    # </source>
 
     <source>
       @id journald-kubelet


### PR DESCRIPTION
We see kata logs with `SYSLOG_IDENTIFIER:kata-runtime` under
`_SYSTEMD_UNIT:crio.service` in kibana. Need to verify if this holds
good for `SYSLOG_IDENTIFIER=kata-proxy` and `SYSLOG_IDENTIFIER=kata-shim`

Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>