### PR TITLE
Do not pin kubernetes version in kubeadm config

### DIFF
--- a/clr-k8s-examples/kubeadm.yaml
+++ b/clr-k8s-examples/kubeadm.yaml
@@ -10,7 +10,6 @@ featureGates:
 ---
 apiVersion: kubeadm.k8s.io/v1alpha3
 kind: ClusterConfiguration
-kubernetesVersion: v1.12.0
 networking:
   dnsDomain: cluster.local
   podSubnet: 10.244.0.0/16


### PR DESCRIPTION
clearlinux-pkgs/kubernetes installs kubeadm kubelet of the same version
and kubeadm uses/fallsback to stable branch of its major+minor version when
generating kubernetes component manifests if none is provided. This
helps with staying upto date with any fixes without any further
modifications

```
vagrant@clr-01 ~ $ bash /vagrant/create_stack.sh
I1207 21:37:25.285850   16086 version.go:236] remote version is much newer: v1.13.0; falling back to: stable-1.12
[init] using Kubernetes version: v1.12.3
```

Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>