### PR TITLE
Set CPUManagerPolicy=static, reserve compute resources

### DIFF
--- a/clr-k8s-examples/kubeadm.yaml
+++ b/clr-k8s-examples/kubeadm.yaml
@@ -7,6 +7,13 @@ apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 featureGates:
   RuntimeClass: true
+cpuManagerPolicy: static
+systemReserved:
+  cpu: 500m
+  memory: 256M
+kubeReserved:
+  cpu: 500m
+  memory: 256M
 ---
 apiVersion: kubeadm.k8s.io/v1alpha3
 kind: ClusterConfiguration

--- a/clr-k8s-examples/tests/test-cpumanager-runc.yaml
+++ b/clr-k8s-examples/tests/test-cpumanager-runc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-cpumanager-runc
+spec:
+  restartPolicy: Never
+  containers:
+  - name: taskset
+    image: busybox
+    command: [ "taskset", "-p", "1" ]
+    resources:
+      limits:
+        cpu: 1
+        memory: 100Mi


### PR DESCRIPTION
Fixes: #8, #16

Setting CPUManagerPolicy=static allows `Guaranteed` QoS class workloads to
get cpu isolation and affinity benefits.
https://kubernetes.io/blog/2018/07/24/feature-highlight-cpu-manager/

Setting reserved compute resources for system processes and critical
kube components prevents from DoS'ing the compute node.
https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/

Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>