### PR TITLE
Temporarily disable cpuManagerPolicy=static

### DIFF
--- a/clr-k8s-examples/kubeadm.yaml
+++ b/clr-k8s-examples/kubeadm.yaml
@@ -7,7 +7,9 @@ apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 featureGates:
   RuntimeClass: true
-cpuManagerPolicy: static
+# Kata does not work with static
+# https://github.com/kata-containers/runtime/issues/878
+# cpuManagerPolicy: static
 systemReserved:
   cpu: 500m
   memory: 256M

--- a/clr-k8s-examples/tests/test-cpumanager-kata.yaml
+++ b/clr-k8s-examples/tests/test-cpumanager-kata.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-cpumanager-kata
+spec:
+  runtimeClassName: kata
+  restartPolicy: Never
+  containers:
+  - name: taskset
+    image: busybox
+    command: [ "taskset", "-p", "1" ]
+    resources:
+      limits:
+        cpu: 1
+        memory: 500Mi


### PR DESCRIPTION
Temporarily disabled `cpuManagerPolicy=static`, issue below
https://github.com/kata-containers/runtime/issues/878

Provided kata equivalent yaml for cpumanager test

Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>