### PR TITLE
Initial support for firecracker configuration on Clearlinux

### DIFF
--- a/clr-k8s-examples/8-kata/fire-runtimeClass.yaml
+++ b/clr-k8s-examples/8-kata/fire-runtimeClass.yaml
@@ -1,0 +1,6 @@
+kind: RuntimeClass
+apiVersion: node.k8s.io/v1alpha1
+metadata:
+    name: fire
+spec:
+    runtimeHandler: fire

--- a/clr-k8s-examples/README.md
+++ b/clr-k8s-examples/README.md
@@ -20,6 +20,11 @@ This script ensures the following
 * Customizes the system to ensure correct defaults are setup (IP Forwarding, Swap off,...)
 * Ensures all the dependencies are loaded on boot (kernel modules)
 
+> EXPERIMENTAL: Optionally run [`setup_firecracker.sh`](setup_firecracker.sh) to be
+able to use firecracker VMM with Kata.
+
+> NOTE: These steps are already done if using vagrant
+
 ## Bring up the master
 
 Run [`create_stack.sh`](create_stack.sh) on the master node. This sets up the

--- a/clr-k8s-examples/Vagrantfile
+++ b/clr-k8s-examples/Vagrantfile
@@ -74,8 +74,8 @@ Vagrant.configure("2") do |config|
       end
       # Bad hack for the vagrant libvirt boxes. WIll be removed once they are fixed.
       c.vm.provision "shell", privileged: false, inline: "sudo usermod --password vagrant root"
-
       c.vm.provision "shell", privileged: false, path: "setup_system.sh"
+      c.vm.provision "shell", privileged: false, path: "setup_firecracker.sh"
     end
   end
 end

--- a/clr-k8s-examples/create_stack.sh
+++ b/clr-k8s-examples/create_stack.sh
@@ -45,7 +45,7 @@ function runtimeclass_kata() {
 		echo "Waiting for runtime class CRD"
 		sleep 2
 	done
-	kubectl apply -f 8-kata/kata-runtimeClass.yaml
+	kubectl apply -f 8-kata/
 }
 
 function cni() {

--- a/clr-k8s-examples/setup_firecracker.sh
+++ b/clr-k8s-examples/setup_firecracker.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+mkdir -p /etc/kata-containers
+
+# Setup a configuration to be used by firecracker
+cat <<EOT | tee /etc/kata-containers/configuration_firecracker.toml
+[hypervisor.firecracker]
+path = "/usr/bin/firecracker"
+kernel = "/usr//share/kata-containers/vmlinux.container"
+image = "/usr//share/kata-containers/kata-containers.img"
+kernel_params = ""
+default_vcpus = 1
+default_memory = 4096
+default_maxvcpus = 0
+default_bridges = 1
+block_device_driver = "virtio-mmio"
+disable_block_device_use = false
+enable_debug = true
+use_vsock = true
+
+[shim.kata]
+path = "/usr//libexec/kata-containers/kata-shim"
+
+[agent.kata]
+
+[runtime]
+internetworking_model="tcfilter"
+EOT
+
+# Firecracker can only work with devicemapper
+# Setup a sparse disk to be used for devicemapper
+rm -f /var/lib/crio/devicemapper/disk.img
+mkdir -p /var/lib/crio/devicemapper
+truncate /var/lib/crio/devicemapper/disk.img --size 10G
+
+# Ensure that this disk is loop mounted at each boot
+mkdir -p /etc/systemd/system
+
+cat <<EOT | tee /etc/systemd/system/devicemapper.service
+[Unit]
+Description=Setup CRIO devicemapper
+DefaultDependencies=no
+After=systemd-udev-settle.service
+Before=lvm2-activation-early.service
+Wants=systemd-udev-settle.service
+
+[Service]
+ExecStart=-/sbin/losetup /dev/loop8 /var/lib/crio/devicemapper/disk.img
+RemainAfterExit=true
+Type=oneshot
+
+[Install]
+WantedBy=local-fs.target
+EOT
+
+systemctl daemon-reload
+systemctl start devicemapper
+
+# For now till we address https://github.com/kubernetes-sigs/cri-o/issues/1991
+# use a shell script to expose firecracker through kata
+cat <<EOT | tee /usr/bin/kata-runtime-fire
+#!/bin/bash
+
+/usr/bin/kata-runtime --kata-config /etc/kata-containers/configuration_firecracker.toml "\$@"
+EOT
+
+chmod +x /usr/bin/kata-runtime-fire
+
+# Add firecracker as a second runtime
+# Also setup crio to use devicemapper
+
+mkdir -p /etc/crio/
+cp /usr/share/defaults/crio/crio.conf /etc/crio/crio.conf
+
+echo -e "\n[crio.runtime.runtimes.kata]\nruntime_path = \"/usr/bin/kata-runtime\"" >> /etc/crio/crio.conf
+echo -e "\n[crio.runtime.runtimes.fire]\nruntime_path = \"/usr/bin/kata-runtime-fire\"" >> /etc/crio/crio.conf
+
+sed -i 's|\(\[crio\.runtime\]\)|\1\nmanage_network_ns_lifecycle = true|' /etc/crio/crio.conf
+
+sed -i 's/storage_driver = \"overlay\"/storage_driver = \"devicemapper\"\
+storage_option = [\
+  \"dm.basesize=8G\",\
+  \"dm.directlvm_device=\/dev\/loop8\",\
+  \"dm.directlvm_device_force=true\",\
+  \"dm.fs=ext4\"\
+]/g' /etc/crio/crio.conf

--- a/clr-k8s-examples/setup_system.sh
+++ b/clr-k8s-examples/setup_system.sh
@@ -3,6 +3,9 @@
 set -o errexit
 set -o nounset
 
+CUR_DIR=$(pwd)
+SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+
 ADD_NO_PROXY="10.244.0.0/16,10.96.0.0/12"
 ADD_NO_PROXY+=",$(hostname -I | sed 's/[[:space:]]/,/g')"
 
@@ -77,6 +80,8 @@ EOF
 	done
 fi
 set -o nounset
+
+sudo $SCRIPT_DIR/setup_firecracker.sh
 
 # We have potentially modified their env files, we need to restart the services.
 sudo systemctl daemon-reload

--- a/clr-k8s-examples/setup_system.sh
+++ b/clr-k8s-examples/setup_system.sh
@@ -3,9 +3,6 @@
 set -o errexit
 set -o nounset
 
-CUR_DIR=$(pwd)
-SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
-
 ADD_NO_PROXY="10.244.0.0/16,10.96.0.0/12"
 ADD_NO_PROXY+=",$(hostname -I | sed 's/[[:space:]]/,/g')"
 
@@ -53,7 +50,7 @@ sudo mkdir -p /usr/libexec/cni /opt/cni
 [ ! -e /opt/cni/bin/cni ] && sudo ln -s /usr/libexec/cni /opt/cni/bin
 #Ensure that the system is ready without requiring a reboot
 sudo swapoff -a
-sudo modprobe br_netfilter vhost_vsock overlay
+sudo systemctl restart systemd-modules-load.service
 
 set +o nounset
 if [[ ${http_proxy} ]] || [[ ${HTTP_PROXY} ]]; then
@@ -80,8 +77,6 @@ EOF
 	done
 fi
 set -o nounset
-
-sudo $SCRIPT_DIR/setup_firecracker.sh
 
 # We have potentially modified their env files, we need to restart the services.
 sudo systemctl daemon-reload

--- a/clr-k8s-examples/tests/test-deploy-fire.yaml
+++ b/clr-k8s-examples/tests/test-deploy-fire.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1 
+kind: Deployment
+metadata:
+  labels:
+    run: php-apache-fire
+  name: php-apache-fire
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: php-apache-fire
+  template:
+    metadata:
+      labels:
+        run: php-apache-fire
+    spec:
+      runtimeClassName: fire
+      containers:
+      - image: k8s.gcr.io/hpa-example
+        imagePullPolicy: Always
+        name: php-apache
+        ports:
+        - containerPort: 80
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 200m
+      restartPolicy: Always
+---
+apiVersion: v1 
+kind: Service
+metadata:
+  name: php-apache-fire
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    run: php-apache-fire
+  sessionAffinity: None
+  type: ClusterIP


### PR DESCRIPTION
Initial support for firecracker configuration on Clearlinux.
This is a little bit complicated due to CRIO requiring a
disk or partition to use devicemapper.

To test 

```
kubectl apply -f 8-kata/fire-runtimeClass.yaml
kubectl apply -f tests/test-deploy-fire.yaml
```


Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>