### PR TITLE
kata-webhook: Change location to katadocker

### DIFF
--- a/clr-k8s-examples/admit-kata/webhook.yaml
+++ b/clr-k8s-examples/admit-kata/webhook.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: pod-annotate-webhook
-          image: mcastelino/kubewebhook-pod-annotate-example:1.0
+          image: katadocker/kata-webhook-example:latest
           imagePullPolicy: Always
           args:
             - -tls-cert-file=/etc/webhook/certs/cert.pem


### PR DESCRIPTION
The kata-webhook is now hosted within the Kata repository.
Switch to using the kata generated images

https://cloud.docker.com/u/katadocker/repository/docker/katadocker/kata-webhook-example
https://github.com/kata-containers/tests/tree/master/kata-webhook

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>