### PR TITLE
Disable devicemapper udev sync

### DIFF
--- a/clr-k8s-examples/setup_kata_firecracker.sh
+++ b/clr-k8s-examples/setup_kata_firecracker.sh
@@ -86,6 +86,7 @@ storage_option = [\
   \"dm.basesize=8G\",\
   \"dm.directlvm_device=\/dev\/loop8\",\
   \"dm.directlvm_device_force=true\",\
+  \"dm.override_udev_sync_check=true",\
   \"dm.fs=ext4\"\
 ]/g' /etc/crio/crio.conf
 


### PR DESCRIPTION
Disable devicemapper udev sync. Without this the storage device
will not be discovered post system reboot

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>