### PR TITLE
Hotfix for rsync update in new clear (box?)

### DIFF
--- a/clr-k8s-examples/Vagrantfile
+++ b/clr-k8s-examples/Vagrantfile
@@ -43,7 +43,8 @@ Vagrant.configure("2") do |config|
 
   # Mount the current dir at home folder instead of default
   config.vm.synced_folder './', '/vagrant', disabled: true
-  config.vm.synced_folder './', '/home/clear/' + File.basename(Dir.getwd), type: 'rsync'
+  config.vm.synced_folder './', '/home/clear/' + File.basename(Dir.getwd), type: 'rsync',
+    rsync__args: ["--verbose", "--archive", "--delete", "-zz", "--copy-links"]
   #Setup proxies for all machines
   (1..$num_instances).each do |i|
     base_ip = base_ip.succ


### PR DESCRIPTION
This was the error

```
==> clr-01: Rsyncing folder: /home/stack/delete/cloud-native-setup-sai/clr-k8s-examples-2/ => /home/clear/clr-k8s-examples-2
There was an error when attempting to rsync a synced folder.
Please inspect the error message below for more info.

Host path: /home/stack/delete/cloud-native-setup-sai/clr-k8s-examples-2/
Guest path: /home/clear/clr-k8s-examples-2
Command: "rsync" "--verbose" "--archive" "--delete" "-z" "--copy-links" "--no-owner" "--no-group" "--rsync-path" "sudo rsync" "-e" "ssh -p 22 -o LogLevel=FATAL   -o ControlMaster=auto -o ControlPath=/tmp/vagrant-rsync-20190226-10142-qkicdt -o ControlPersist=10m  -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i '/home/stack/.vagrant.d/insecure_private_key'" "--exclude" ".vagrant/" "/home/stack/delete/cloud-native-setup-sai/clr-k8s-examples-2/" "clear@192.168.121.233:/home/clear/clr-k8s-examples-2"
Error: rsync: This rsync lacks old-style --compress due to its external zlib.  Try -zz.
rsync error: syntax or usage error (code 1) at main.c(1578) [server=3.1.3]
rsync: connection unexpectedly closed (0 bytes received so far) [sender]
rsync error: error in rsync protocol data stream (code 12) at io.c(235) [sender=3.1.2]
```

Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>