### PR TITLE
 Update webhook setup and documentation

### DIFF
--- a/clr-k8s-examples/7-rook/000-operator.yaml
+++ b/clr-k8s-examples/7-rook/000-operator.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rook-ceph-system
-  labels:
-    kata: "false"
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/clr-k8s-examples/7-rook/001-cluster.yaml
+++ b/clr-k8s-examples/7-rook/001-cluster.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rook-ceph
-  labels:
-    kata: "false"
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/clr-k8s-examples/README.md
+++ b/clr-k8s-examples/README.md
@@ -102,30 +102,11 @@ and sample admission controller we created by running -
 `kubectl apply -f admit-kata/`
 
 The [admission webhook](admit-kata/webhook-registration.yaml)
-is setup to exclude certian namespaces from being run with Kata using filters on namespace labels.
 
-```yaml
-    namespaceSelector:
-      matchExpressions:
-        -  {key: "kata", operator: NotIn, values: ["false"]}
-```
+The webhook mutates pods to use the kata runtime class for all pods except those with
 
-The rook operators for example are marked as such
-
-```yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: rook-ceph-system
-  labels:
-    kata: "false"
-```
-
-Pods not explicitly excluded by the namespace filter are dynamically tagged to
-run with Kata with some [exceptions](https://github.com/mcastelino/kubewebhook/blob/topic/hack-kata/examples/pod-annotate/main.go#L25) -
-
-* `hostNetwork: true`
-* `rook-ceph` and `rook-ceph-system` namespaces (buggy)
+- hostNetwork: true
+- namespace: rook-ceph and rook-ceph-system
 
 Other pod properties will be added as exceptions in future.
 

--- a/clr-k8s-examples/admit-kata/webhook-registration.yaml
+++ b/clr-k8s-examples/admit-kata/webhook-registration.yaml
@@ -18,7 +18,3 @@ webhooks:
         apiGroups: [""]
         apiVersions: ["v1"]
         resources: ["pods"]
-    namespaceSelector:
-      matchExpressions:
-        -  {key: "kata", operator: NotIn, values: ["false"]}
-

--- a/clr-k8s-examples/tests/deploy-svc-ing/test-deploy-kata-qemu.yaml
+++ b/clr-k8s-examples/tests/deploy-svc-ing/test-deploy-kata-qemu.yaml
@@ -11,9 +11,6 @@ spec:
       run: php-apache-kata-qemu
   template:
     metadata:
-      annotations:
-        io.kubernetes.cri-o.TrustedSandbox: "false"
-        io.kubernetes.cri.untrusted-workload: "true"
       labels:
         run: php-apache-kata-qemu
     spec:


### PR DESCRIPTION
The admission controller is now able to access full context. Hence explicit tagging of pod manifests to exclude them from kata is no longer required.

Additonally, we only support kubernetes versions with support for runtimeClass.  Remove the legacy annotations to reduce confusion.

