### PR TITLE
Do not restart containerd, remove stop kubelet

### DIFF
--- a/clr-k8s-examples/9-multi-network/multus-sriov-ds.yaml
+++ b/clr-k8s-examples/9-multi-network/multus-sriov-ds.yaml
@@ -140,10 +140,8 @@ spec:
         - cp /tmp/cni/bin/{multus,sriov,vfioveth,jq} /host/opt/cni/bin/;
           /tmp/multus/install-multus-conf.sh;
           /tmp/multus/install-certs.sh;
-          systemctl stop kubelet;
-          echo "Restarting crio/containerd, kubelet";
-          systemctl restart containerd;
-          systemctl restart crio;
+          echo "Restarting crio kubelet";
+          systemctl restart crio; # Needed when crio manages ns lifecycle
           systemctl restart kubelet;
         volumeMounts:
         - name: usr-bin


### PR DESCRIPTION
In case of containerd there is no need to restart. Restart for crio is needed
when it manages the networks ns lifecycle. Removed the kubelet stop step which
was a leftover from earlier device plugin install.

Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>