### PR TITLE
Turn on static policy for CPU manager

### DIFF
--- a/clr-k8s-examples/kubeadm.yaml
+++ b/clr-k8s-examples/kubeadm.yaml
@@ -7,9 +7,8 @@ apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 featureGates:
   RuntimeClass: true
-# Kata does not work with static
-# https://github.com/kata-containers/runtime/issues/878
-# cpuManagerPolicy: static
+# Allowing for CPU pinning and isolation in case of guaranteed QoS class
+cpuManagerPolicy: static
 systemReserved:
   cpu: 500m
   memory: 256M

--- a/clr-k8s-examples/tests/cpumanager/test-cpumanager.yaml.tmpl
+++ b/clr-k8s-examples/tests/cpumanager/test-cpumanager.yaml.tmpl
@@ -12,7 +12,7 @@ spec:
     resources:
       limits:
         cpu: 1
-        memory: 100Mi
+        memory: 500Mi # For kata to run
 ---
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
This is finally supported in Kata 1.6
Update memory limit for kata to run in guaranteed test case

Resolves #71 

Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>