### PR TITLE
kata-deploy: update to match what's on Kata master

### DIFF
--- a/clr-k8s-examples/8-kata/deploy/kata-cleanup.yaml
+++ b/clr-k8s-examples/8-kata/deploy/kata-cleanup.yaml
@@ -20,7 +20,7 @@ spec:
       - name: kube-kata-cleanup
         image: katadocker/kata-deploy
         imagePullPolicy: Always
-        command: ["/bin/bash", "-c", "/opt/kata-artifacts/scripts/kata-deploy.sh reset"]
+        command: [ "bash", "-c", "/opt/kata-artifacts/scripts/kata-deploy.sh reset" ]
         env:
         - name: NODE_NAME
           valueFrom:

--- a/clr-k8s-examples/8-kata/deploy/kata-deploy.yaml
+++ b/clr-k8s-examples/8-kata/deploy/kata-deploy.yaml
@@ -21,8 +21,8 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["/bin/bash", "-c", "/opt/kata-artifacts/scripts/kata-deploy.sh cleanup"]
-        command: ["/bin/bash", "-c", "/opt/kata-artifacts/scripts/kata-deploy.sh install"]
+              command: ["bash", "-c", "/opt/kata-artifacts/scripts/kata-deploy.sh cleanup"]
+        command: [ "bash", "-c", "/opt/kata-artifacts/scripts/kata-deploy.sh install" ]
         env:
         - name: NODE_NAME
           valueFrom:
@@ -41,6 +41,8 @@ spec:
           mountPath: /var/run/dbus
         - name: systemd
           mountPath: /run/systemd
+        - name: local-bin
+          mountPath: /usr/local/bin/
       volumes:
         - name: crio-conf
           hostPath:
@@ -58,6 +60,9 @@ spec:
         - name: systemd
           hostPath:
             path: /run/systemd
+        - name: local-bin
+          hostPath:
+            path: /usr/local/bin/
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1


### PR DESCRIPTION
We updated to use containerd v2 shim - pull in latest from master

Noticed there's been a discrepancy in the yaml between Kata and this repo for /bin/bash v. bash.  PTAL at this @krsna1729 ?