### PR TITLE
Set reverse path forwarding to strict.

### DIFF
--- a/clr-k8s-examples/setup_system.sh
+++ b/clr-k8s-examples/setup_system.sh
@@ -22,6 +22,7 @@ fi
 sudo mkdir -p /etc/sysctl.d/
 cat <<EOT | sudo bash -c "cat > /etc/sysctl.d/60-k8s.conf"
 net.ipv4.ip_forward=1
+net.ipv4.conf.default.rp_filter=1
 EOT
 sudo systemctl restart systemd-sysctl
 


### PR DESCRIPTION
Calico requires the default reverse path forwarding to be either 0 (no
validation) or 1 (strict validation). The default value of 2 (loose
validation) prevents calico from completing the setup and the pod is
always stuck getting ready.

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>