### PR TITLE
stack: dont provide CRI socket

### DIFF
--- a/clr-k8s-examples/kubeadm.yaml
+++ b/clr-k8s-examples/kubeadm.yaml
@@ -1,7 +1,5 @@
 apiVersion: kubeadm.k8s.io/v1beta1
 kind: InitConfiguration
-nodeRegistration:
-  criSocket: /var/run/crio/crio.sock
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration

--- a/clr-k8s-examples/reset_stack.sh
+++ b/clr-k8s-examples/reset_stack.sh
@@ -3,7 +3,10 @@
 set -o nounset
 
 #Cleanup
-sudo -E kubeadm reset -f --cri-socket="/var/run/crio/crio.sock"
+reset_cluster() {
+	sudo -E kubeadm reset -f
+}
+reset_cluster
 
 for ctr in $(sudo crictl ps --quiet); do
 	sudo crictl stop "$ctr"
@@ -43,4 +46,4 @@ sudo systemctl enable kubelet crio
 sudo systemctl restart crio
 sudo systemctl restart kubelet
 
-sudo -E kubeadm reset -f --cri-socket="/var/run/crio/crio.sock"
+reset_cluster


### PR DESCRIPTION


kubeadm autodetects the socket path based on defaults from well known
CRI servers.

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>