### PR TITLE
calico-node fails to come up cause of all.rp_filter

### DIFF
--- a/clr-k8s-examples/setup_system.sh
+++ b/clr-k8s-examples/setup_system.sh
@@ -23,6 +23,7 @@ sudo mkdir -p /etc/sysctl.d/
 cat <<EOT | sudo bash -c "cat > /etc/sysctl.d/60-k8s.conf"
 net.ipv4.ip_forward=1
 net.ipv4.conf.default.rp_filter=1
+net.ipv4.conf.all.rp_filter=1
 EOT
 sudo systemctl restart systemd-sysctl
 


### PR DESCRIPTION
Currently net.ipv4.conf.all.rp_filter is set to 2 in Clear and
calico-node fails to come up unless that value is either 0 or 1.

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>