### PR TITLE
cri-o update fixes

### DIFF
--- a/clr-k8s-examples/setup_system.sh
+++ b/clr-k8s-examples/setup_system.sh
@@ -52,8 +52,6 @@ sudo systemctl daemon-reload
 echo "The following kubelet command may complain... it is not an error"
 sudo systemctl enable --now kubelet crio || true
 
-sudo mkdir -p /usr/libexec/cni /opt/cni
-[ ! -e /opt/cni/bin/cni ] && sudo ln -s /usr/libexec/cni /opt/cni/bin
 #Ensure that the system is ready without requiring a reboot
 sudo swapoff -a
 sudo systemctl restart systemd-modules-load.service


### PR DESCRIPTION
ClearLinux now has cri-o version 1.14.1 which allows multiple plugin
locations and also creates /opt/cni/bin by default. We no longer need
the hacks for them

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>