### PR TITLE
Configure canal to ignore rpf instead of host

### DIFF
--- a/clr-k8s-examples/0-canal/canal.yaml
+++ b/clr-k8s-examples/0-canal/canal.yaml
@@ -159,6 +159,8 @@ spec:
               value: "info"
             - name: FELIX_HEALTHENABLED
               value: "true"
+            - name: FELIX_IGNORELOOSERPF
+              value: "true"
           securityContext:
             privileged: true
           resources:

--- a/clr-k8s-examples/setup_system.sh
+++ b/clr-k8s-examples/setup_system.sh
@@ -22,8 +22,6 @@ fi
 sudo mkdir -p /etc/sysctl.d/
 cat <<EOT | sudo bash -c "cat > /etc/sysctl.d/60-k8s.conf"
 net.ipv4.ip_forward=1
-net.ipv4.conf.default.rp_filter=1
-net.ipv4.conf.all.rp_filter=1
 EOT
 sudo systemctl restart systemd-sysctl
 


### PR DESCRIPTION
Modifying rp_filter setting on host seems to be causing a routing issue
when connecting to a pod from remote node. Until we figure out the best
way to solve the issue, we are configuring canal to ignore default
setting of 2

Fixes: #102

Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>