### PR TITLE
Workaround: Kubernetes breaks on Clearlinux with multiple interfaces

### DIFF
--- a/clr-k8s-examples/Vagrantfile
+++ b/clr-k8s-examples/Vagrantfile
@@ -62,7 +62,7 @@ Vagrant.configure("2") do |config|
   $hosts.each do |vm_name, ip|
     config.vm.define vm_name do |c|
       c.vm.hostname = vm_name
-      c.vm.network :private_network, ip: ip, autostart: true
+      #c.vm.network :private_network, ip: ip, autostart: true
       c.vm.provider :libvirt do |lv|
         lv.cpu_mode = "host-passthrough"
         lv.nested = true


### PR DESCRIPTION
For now till the bug is root caused and fixed disable the private
network.

Workaround for:
https://github.com/clearlinux/cloud-native-setup/issues/105

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>