### PR TITLE
Versioning: Update clearlinux version to 30270

### DIFF
--- a/clr-k8s-examples/Vagrantfile
+++ b/clr-k8s-examples/Vagrantfile
@@ -43,7 +43,7 @@ Vagrant.configure("2") do |config|
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
   config.vm.box = $box
-  config.vm.box_version = "29820"
+  config.vm.box_version = "30260"
 
   # Mount the current dir at home folder instead of default
   config.vm.synced_folder './', '/vagrant', disabled: true

--- a/clr-k8s-examples/setup_system.sh
+++ b/clr-k8s-examples/setup_system.sh
@@ -7,7 +7,7 @@ ADD_NO_PROXY="10.244.0.0/16,10.96.0.0/12"
 ADD_NO_PROXY+=",$(hostname -I | sed 's/[[:space:]]/,/g')"
 
 #Install kubernetes and crio
-sudo -E swupd repair --picky -m 29880 --force
+sudo -E swupd repair --picky -m 30270 --force
 sudo -E swupd bundle-add cloud-native-basic storage-utils
 
 #Permanently disable swap


### PR DESCRIPTION
Clearlinux release 30270 is now a known good version compatible
with kubernetes.

RuntimeName:  cri-o
RuntimeVersion:  1.14.4
RuntimeApiVersion:  v1alpha1

Kubernetes v1.15.0

runc version 1.0.0-rc5
spec: 1.0.0

systemd 242 (242)
+PAM +AUDIT -SELINUX +IMA -APPARMOR -SMACK -SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ -LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD -IDN2 -IDN -PCRE2 default-hierarchy=legacy

Kernel: 4.19.57-60.lts2018

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>