### PR TITLE
Move to containerd as the default manager

### DIFF
--- a/clr-k8s-examples/Vagrantfile
+++ b/clr-k8s-examples/Vagrantfile
@@ -20,6 +20,10 @@ $hosts = {}
 $proxy_ip_list = ""
 $driveletters = ('a'..'z').to_a
 $setup_fc = true ? (['true', '1'].include? ENV['SETUP_FC'].to_s) : false
+$runner = ENV.has_key?('RUNNER') ? ENV['RUNNER'].to_s : "containerd".to_s
+if !(["crio","containerd"].include? $runner)
+  abort("it's either crio or containerd. Cannot do anything else")
+end
 
 if not File.exists?($loader)
   system('curl -O https://download.clearlinux.org/image/OVMF.fd')
@@ -80,9 +84,17 @@ Vagrant.configure("2") do |config|
           c.proxy.no_proxy =  (ENV['no_proxy']+"#{proxy_ip_list}" || ENV['NO_PROXY']+"#{proxy_ip_list}" || "localhost,127.0.0.1,172.16.10.10#{proxy_ip_list}")
         end
       end
-      c.vm.provision "shell", privileged: false, path: "setup_system.sh"
+      c.vm.provision "shell", privileged: false, path: "setup_system.sh", env: {"RUNNER" => $runner}
       if $setup_fc
+        if $runner == "crio".to_s
         c.vm.provision "shell", privileged: false, path: "setup_kata_firecracker.sh"
+        else
+        # Wish we could use device mapper snapshotter with containerd, but it
+        # does not exist on any released containerd version. Failing for now
+        # when we use FC with containerd
+        abort("Cannot use containerd with FC for now.")
+        #c.vm.provision "shell", privileged: false, path: "containerd_devmapper_setup.sh"
+        end
       end
       # Include shells bundle to get bash completion and add kubectl's commands to vagrant's shell
       c.vm.provision "shell", privileged: false, inline: 'sudo -E swupd bundle-add shells; echo "source <(kubectl completion bash)" >> $HOME/.bashrc'

--- a/clr-k8s-examples/containerd_devmapper_setup.sh
+++ b/clr-k8s-examples/containerd_devmapper_setup.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+sudo rm -rf /var/lib/containerd/devmapper/data-disk.img
+sudo rm -rf /var/lib/containerd/devmapper/meta-disk.img
+sudo mkdir -p /var/lib/containerd/devmapper
+sudo truncate --size 10G /var/lib/containerd/devmapper/data-disk.img
+sudo truncate --size 10G /var/lib/containerd/devmapper/meta-disk.img
+
+sudo mkdir -p /etc/systemd/system
+
+cat<<EOT | sudo tee /etc/systemd/system/containerd-devmapper.service
+[Unit]
+Description=Setup containerd devmapper device
+DefaultDependencies=no
+After=systemd-udev-settle.service
+Before=lvm2-activation-early.service
+Wants=systemd-udev-settle.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=-/sbin/losetup /dev/loop20 /var/lib/containerd/devmapper/data-disk.img
+ExecStart=-/sbin/losetup /dev/loop21 /var/lib/containerd/devmapper/meta-disk.img
+
+[Install]
+WantedBy=local-fs.target
+EOT
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now containerd-devmapper
+
+# Time to setup the thin pool for consumption.
+# The table arguments are such.
+# start block in the virtual device
+# length of the segment (block device size in bytes / Sector size (512)
+# metadata device
+# block data device
+# data_block_size Currently set it 512 (128KB)
+# low_water_mark. Copied this from containerd snapshotter test setup
+# no. of feature arguments
+# Skip zeroing blocks for new volumes.
+sudo dmsetup create contd-thin-pool \
+  --table "0 2097152 thin-pool /dev/loop21 /dev/loop20 512 32768 1 skip_block_zeroing"
+
+sudo mkdir -p /etc/containerd/
+if [ -f /etc/containerd/config.toml ]
+then
+  sudo sed -i 's|^\(\[plugins\]\).*|\1\n  \[plugins.devmapper\]\n    pool_name = \"contd-thin-pool\"\n    base_image_size = \"512MB\"|' /etc/containerd/config.toml
+else
+  cat<<EOT | sudo tee /etc/containerd/config.toml
+[plugins]
+  [plugins.devmapper]
+    pool_name = "contd-thin-pool"
+    base_image_size = "512MB"
+EOT
+fi
+
+sudo systemctl restart containerd


### PR DESCRIPTION
This setup scripts have been using cri-o all this while as the pod
controller/manager system. Recent past cri-o has had some issues with
kata-deploy (A restart of the service will not be able to re-connect
with the existing pods and restart all of them including kata-deploy,
which will hit an endless loop). Moving to containerd as default for
now.

Firecracker cannot be used with a released version of containerd as
there is no default block based snapshotter available today. If you wish
to use cri-o make sure you set `RUNNER=crio` in your environment prior
to using the script.

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>