### PR TITLE
Add option to use API to launch

### DIFF
--- a/metrics/scaling/bb.json.in
+++ b/metrics/scaling/bb.json.in
@@ -1,0 +1,42 @@
+{
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+        "labels": {
+            "run": "busybox"
+        },
+        "name": "@DEPLOYMENT@"
+    },
+    "spec": {
+        "replicas": @REPLICAS@,
+        "selector": {
+            "matchLabels": {
+                "run": "busybox"
+            }
+        },
+        "template": {
+            "metadata": {
+                "labels": {
+                    "run": "busybox",
+                    "@LABEL@": "@LABELVALUE@"
+                }
+            },
+            "spec": {
+                "runtimeClassName": "@RUNTIMECLASS@",
+                "automountServiceAccountToken": false,
+                "containers": [{
+                    "name": "bb",
+                    "image": "busybox",
+                    "command": [
+                        "tail",
+                        "-f",
+                        "/dev/null"
+                    ],
+                    "stdin": true,
+                    "tty": true
+                }],
+                "restartPolicy": "Always"
+            }
+        }
+    }
+}

--- a/metrics/scaling/bb.yaml.in
+++ b/metrics/scaling/bb.yaml.in
@@ -25,6 +25,7 @@ spec:
         @LABEL@: @LABELVALUE@
     spec:
       runtimeClassName: @RUNTIMECLASS@
+      automountServiceAccountToken: false
       containers:
       - name: bb
         image: busybox


### PR DESCRIPTION
Adds option to use_api for launch calls (currently). Fixed missing tab indent issues. Also supports starting or finding the kubectl proxy process and using that address and port for API calls.

<s>Eventually, I think we'll want to not just update the same deployment, but rather launch separate deployments so we can track shutdown time. I have a version of that working too, but this is a start.</s>

After playing more with OpenFaaS, I think we should stick with this model. It more closely duplicates their model.

The other option is https://github.com/dklyle/cloud-native-setup/tree/use-api-launch-2, but I think we can just track pods in this model.