### PR TITLE
metrics: scaling: change check for 'first deploy' to non-1 indexed

### DIFF
--- a/metrics/scaling/k8s_scale.sh
+++ b/metrics/scaling/k8s_scale.sh
@@ -191,7 +191,8 @@ run() {
 		info "Applying changes"
 		local start_time=$(date +%s%N)
 		if [ "$use_api" != "no" ]; then
-			if [ $reqs == 1 ]; then
+			# If this is the first launch of the deploy, we need to use a different URL form.
+			if [ $reqs == ${STEP} ]; then
 				curl -s ${API_ADDRESS}:${API_PORT}/apis/apps/v1/namespaces/default/deployments -XPOST -H 'Content-Type: application/json' -d@${generated_file} > /dev/null
 			else
 				curl -s ${API_ADDRESS}:${API_PORT}/apis/apps/v1/namespaces/default/deployments/${deployment} -XPATCH -H 'Content-Type:application/strategic-merge-patch+json' -d@${generated_file} > /dev/null


### PR DESCRIPTION
We need to check when we are launching our first instance of a
deployment when using the k8s API directly, as we have to modify
the URL for the first instance. Rather than check for '1', let's
check for 'STEP', as technically you can run the loop starting at
a non-1 index (particularly useful to run with NUM_PODS==STEP, as
you then get a 'single shot' test of 'n' containers).

Signed-off-by: Graham Whaley <graham.whaley@intel.com>