### PR TITLE
Allow bootstrap token and master_ip to be customizable

### DIFF
--- a/clr-k8s-examples/create_stack.sh
+++ b/clr-k8s-examples/create_stack.sh
@@ -29,6 +29,12 @@ function finish() {
 trap finish EXIT
 
 function cluster_init() {
+  if ! [ -z ${TOKEN} ]; then
+    sed -i "/InitConfiguration/a bootstrapTokens:\\n- token: ${TOKEN}" ./kubeadm.yaml
+  fi
+  if ! [ -z ${MASTER_IP} ]; then
+    sed -i "/InitConfiguration/a localAPIEndpoint:\\n  advertiseAddress: ${MASTER_IP}" ./kubeadm.yaml
+  fi
 	#This only works with kubernetes 1.12+. The kubeadm.yaml is setup
 	#to enable the RuntimeClass featuregate
 	sudo -E kubeadm init --config=./kubeadm.yaml


### PR DESCRIPTION
This change will allow the create_stack.sh script to be called to init
the k8s cluster with a user generated bootstrap token and a pre-defined
master_ip. This will allow us to automate initial deployment of cluster
with a known list of IPs

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>