### PR TITLE
Multinode support

### DIFF
--- a/metrics/report/report_dockerfile/scaling.R
+++ b/metrics/report/report_dockerfile/scaling.R
@@ -56,8 +56,8 @@ for (currentdir in resultdirs) {
 
 			testname=datasetname
 
-			cdata=data.frame(avail_gb=as.numeric(fdata$BootResults$mem_free$Result)/(1024*1024))
-			cdata=cbind(cdata, cpu_idle=as.numeric(fdata$BootResults$cpu_idle$Result))
+			cdata=data.frame(avail_gb=as.numeric(fdata$BootResults$node_util$mem_free$Result)/(1024*1024))
+			cdata=cbind(cdata, cpu_idle=as.numeric(fdata$BootResults$node_util$cpu_idle$Result))
 			# convert ms to seconds
 			cdata=cbind(cdata, boot_time=as.numeric(fdata$BootResults$launch_time$Result)/1000)
 			# FIXME - we should seq from 0 index
@@ -125,7 +125,7 @@ mem_stats_plot = suppressWarnings(ggtexttable(data.frame(rstats),
 	rows=NULL
 	))
 
-# plot how samples varioed over  'time'
+# plot how samples varied over  'time'
 mem_line_plot <- ggplot() +
 	geom_line( data=data, aes(count, avail_gb, colour=testname, group=dataset), alpha=0.2) +
 	geom_smooth( data=data, aes(count, avail_gb, colour=testname, group=dataset), se=FALSE, method="loess", size=0.3) +

--- a/metrics/report/report_dockerfile/scaling.R
+++ b/metrics/report/report_dockerfile/scaling.R
@@ -132,11 +132,11 @@ for (currentdir in resultdirs) {
 				node_avail_gb=paste(nodename, "_avail_gb", sep="")
 				# Work out memory reduction by subtracting last (most consumed) from
 				srdata=cbind(mem_consumed=as.numeric(as.character(cdata[, node_avail_gb][1])) -
-					     as.numeric(as.character(cdata[, node_avail_gb][length(cdata[, node_avail_gb])])))
+							 as.numeric(as.character(cdata[, node_avail_gb][length(cdata[, node_avail_gb])])))
 				
 				node_cpu_idle=paste(nodename, "_cpu_idle", sep="")
 				srdata=cbind(srdata, cpu_consumed=as.numeric(as.character(cdata[, node_cpu_idle][1])) -
-					     as.numeric(as.character(cdata[, node_cpu_idle][length(cdata[, node_cpu_idle])])))
+							 as.numeric(as.character(cdata[, node_cpu_idle][length(cdata[, node_cpu_idle])])))
 				sudata=rbind(sudata, srdata)
 			}
 			sdata=cbind(sdata, mem_consumed=sum(sudata[, "mem_consumed"]))
@@ -185,10 +185,10 @@ mem_stats_plot = suppressWarnings(ggtexttable(data.frame(rstats),
 	rows=NULL
 	))
 
-# plot how samples varied over  'time'
-mem_line_plot <- ggplot(data=fndata, aes(as.numeric(as.character(pod)), 
-						    as.numeric(as.character(mem_free)), 
-						    colour=interaction(testname, node), group=interaction(testname, node))) +
+# plot how samples varied over	'time'
+mem_line_plot <- ggplot(data=fndata, aes(as.numeric(as.character(pod)),
+							as.numeric(as.character(mem_free)),
+							colour=interaction(testname, node), group=interaction(testname, node))) +
 	geom_line(alpha=0.2) +
 	geom_smooth(se=FALSE, method="loess", size=0.3) +
 	xlab("Pods") +
@@ -209,10 +209,10 @@ cpu_stats_plot = suppressWarnings(ggtexttable(data.frame(cstats),
 	rows=NULL
 	))
 
-# plot how samples varied over  'time'
-cpu_line_plot <- ggplot(data=fndata, aes(as.numeric(as.character(pod)), 
-						    as.numeric(as.character(cpu_idle)), 
-						    colour=interaction(testname, node), group=interaction(testname, node))) +
+# plot how samples varied over	'time'
+cpu_line_plot <- ggplot(data=fndata, aes(as.numeric(as.character(pod)),
+							as.numeric(as.character(cpu_idle)),
+							colour=interaction(testname, node), group=interaction(testname, node))) +
 	geom_line(alpha=0.2) +
 	geom_smooth(se=FALSE, method="loess", size=0.3) +
 	xlab("Pods") +
@@ -246,7 +246,7 @@ cpu_text <- paste("System CPU consumption statistics")
 cpu_text.p <- ggparagraph(text=cpu_text, face="italic", size="10", color="black")
 
 # See https://www.r-bloggers.com/ggplot2-easy-way-to-mix-multiple-graphs-on-the-same-page/ for
-# excellent examples 
+# excellent examples
 master_plot = grid.arrange(
 	mem_line_plot,
 	cpu_line_plot,
@@ -256,5 +256,5 @@ master_plot = grid.arrange(
 	cpu_text.p,
 	boot_line_plot,
 	nrow=7,
-        heights=c(1, 1, 0.8, 0.1, 0.8, 0.1, 1) )
+	heights=c(1, 1, 0.8, 0.1, 0.8, 0.1, 1) )
 

--- a/metrics/report/report_dockerfile/scaling.R
+++ b/metrics/report/report_dockerfile/scaling.R
@@ -58,7 +58,7 @@ for (currentdir in resultdirs) {
 			testname=datasetname
 
 			cdata=data.frame(boot_time=as.numeric(fdata$BootResults$launch_time$Result)/1000)
-			
+
 			# format the utilization data
 			udata=data.frame(nodename=fdata$BootResults$node_util)
 			for (i in seq(length(cdata[, "boot_time"]))) {
@@ -69,7 +69,11 @@ for (currentdir in resultdirs) {
 					c3=cbind(udata$nodename.mem_free$Result)/(1024*1024)
 					c4=cbind(rep(i, length(udata$nodename.node)))
 					c5=cbind(rep(testname, length(udata$nodename.node)))
-					# declare formated utility data
+					# FIXME figure out how to add schedule here ###
+					# then add to cdata below as well ###
+					# then update calculations to exclude schedule=false ###
+
+					# declare formatted utility data
 					fudata=cbind(c1,c2,c3,c4,c5)
 				}
 				else {
@@ -87,15 +91,14 @@ for (currentdir in resultdirs) {
 					# create the new row (which is actually the number of nodes of rows)
 					frow=cbind(c1,c2,c3,c4,c5)
 					fudata=rbind(fudata,frow)
-
 				}
 			}
 			colnames(fudata)=c("node", "cpu_idle", "mem_free", "pod", "testname")
-			# fudata is considered a vector for some reason so converting it to a data.frame	
+			# fudata is considered a vector for some reason so converting it to a data.frame
 			fudata=as.data.frame(fudata)
 			# get unique node names
 			nodes=unique(fudata$node)
-			
+
 
 			for (nodename in nodes) {
 				c1=cbind(subset(fudata,node==nodename)["mem_free"])
@@ -107,7 +110,7 @@ for (currentdir in resultdirs) {
 				colnames(c2)=paste(nodename,"_cpu_idle", sep="")
 				cdata=cbind(cdata, c2)
 			}
-			
+
 			# convert ms to seconds
 			# FIXME - we should seq from 0 index
 			if (length(cdata[, "boot_time"]) > 20) {
@@ -187,10 +190,9 @@ mem_stats_plot = suppressWarnings(ggtexttable(data.frame(rstats),
 
 # plot how samples varied over	'time'
 mem_line_plot <- ggplot(data=fndata, aes(as.numeric(as.character(pod)),
-							as.numeric(as.character(mem_free)),
-							colour=interaction(testname, node), group=interaction(testname, node))) +
+		as.numeric(as.character(mem_free)),
+		colour=testname, group=interaction(testname, node))) +
 	geom_line(alpha=0.2) +
-	geom_smooth(se=FALSE, method="loess", size=0.3) +
 	xlab("Pods") +
 	ylab("System Avail (Gb)") +
 	scale_y_continuous(labels=comma) +
@@ -201,20 +203,16 @@ mem_line_plot <- ggplot(data=fndata, aes(as.numeric(as.character(pod)),
 # If we only have relatively few samples, add points to the plot. Otherwise, skip as
 # the plot becomes far too noisy
 if ( skip_points == 0 ) {
-	mem_line_plot = mem_line_plot + geom_point(alpha=0.3)
+	mem_line_plot = mem_line_plot + geom_point(aes(shape=node), alpha=0.3)
 }
 
-cpu_stats_plot = suppressWarnings(ggtexttable(data.frame(cstats),
-	theme=ttheme(base_size=10),
-	rows=NULL
-	))
+cpu_stats_plot = suppressWarnings(ggtexttable(data.frame(cstats), theme=ttheme(base_size=10), rows=NULL))
 
-# plot how samples varied over	'time'
+# plot how samples varied over 'time'
 cpu_line_plot <- ggplot(data=fndata, aes(as.numeric(as.character(pod)),
-							as.numeric(as.character(cpu_idle)),
-							colour=interaction(testname, node), group=interaction(testname, node))) +
+		as.numeric(as.character(cpu_idle)),
+		colour=testname, group=interaction(testname, node))) +
 	geom_line(alpha=0.2) +
-	geom_smooth(se=FALSE, method="loess", size=0.3) +
 	xlab("Pods") +
 	ylab("System CPU Idle (%)") +
 	ggtitle("System CPU usage") +
@@ -222,7 +220,7 @@ cpu_line_plot <- ggplot(data=fndata, aes(as.numeric(as.character(pod)),
 	theme(axis.text.x=element_text(angle=90))
 
 if ( skip_points == 0 ) {
-	cpu_line_plot = cpu_line_plot + geom_point(alpha=0.3)
+	cpu_line_plot = cpu_line_plot + geom_point(aes(shape=node), alpha=0.3)
 }
 
 # Show how boot time changed
@@ -256,5 +254,5 @@ master_plot = grid.arrange(
 	cpu_text.p,
 	boot_line_plot,
 	nrow=7,
-	heights=c(1, 1, 0.8, 0.1, 0.8, 0.1, 1) )
+	heights=c(1.5, 1.5, 0.8, 0.1, 0.8, 0.1, 1.2) )
 

--- a/metrics/scaling/k8s_scale.sh
+++ b/metrics/scaling/k8s_scale.sh
@@ -39,41 +39,68 @@ TEST_NAME="k8s scaling"
 grab_stats() {
 	local launch_time_ms=$1
 	local n_pods=$2
+    local cpu_idle=()
+    local mem_free=()
 	info "And grab some stats"
-	# Tell mpstat to measure over a short period, not only so we get slightly de-noised data, but also
-	# if you don't tell it the period, you will get the avg since boot, which is not what we want.
-	local cpu_idle=$(kubectl exec -ti ${stats_pod} -- sh -c "mpstat -u 3 1 | tail -1 | awk '{print \$11}'" | sed 's/\r//')
-	local mem_free=$(kubectl exec -ti ${stats_pod} -- sh -c "free | tail -2 | head -1 | awk '{print \$4}'" | sed 's/\r//')
 
-	info "idle [$cpu_idle] free [$mem_free] launch [$launch_time]"
-
-	# Annoyingly, it seems sometimes once in a while we don't get an answer!
-	# We should really retry, but for now, make the json valid at least
-	cpu_idle=${cpu_idle:-0}
-	mem_free=${mem_free:-0}
-
-	local json="$(cat << EOF
-	{
-		"n_pods": {
-			"Result": ${n_pods},
-			"Units" : "int"
-		},
-		"cpu_idle": {
-			"Result": ${cpu_idle},
-			"Units" : "%"
-		},
-		"launch_time": {
-			"Result": $launch_time_ms,
-			"Units" : "ms"
-		},
-		"mem_free": {
-			"Result": ${mem_free},
-			"Units" : "kb"
-		}
-	}
+    local pods_json="$(cat << EOF
+            "n_pods": {
+                "Result": ${n_pods},
+                "Units" : "int"
+            }
 EOF
-)"
-	metrics_json_add_array_element "$json"
+    )"
+    metrics_json_add_array_fragment "$pods_json"
+
+    local launch_json="$(cat << EOF
+            "launch_time": {
+                "Result": $launch_time_ms,
+                "Units" : "ms"
+            }
+EOF
+    )"
+    metrics_json_add_array_fragment "$launch_json"
+
+    metrics_json_start_nested_array
+
+    # grab pods in the stats daemonset
+    # use 3 for the file descriptor rather than stdin otherwise the sh commands
+    # in the middle will read the rest of stdin
+    while read -u 3 name node; do
+        # Tell mpstat to measure over a short period, not only so we get slightly de-noised data, but also
+        # if you don't tell it the period, you will get the avg since boot, which is not what we want.
+        local cpu_idle=$(kubectl exec -ti $name -- sh -c "mpstat -u 3 1 | tail -1 | awk '{print \$11}'" | sed 's/\r//')
+        local mem_free=$(kubectl exec -ti $name -- sh -c "free | tail -2 | head -1 | awk '{print \$4}'" | sed 's/\r//')
+
+        info "idle [$cpu_idle] free [$mem_free] launch [$launch_time_ms] node [$node]"
+
+        # Annoyingly, it seems sometimes once in a while we don't get an answer!
+        # We should really retry, but for now, make the json valid at least
+        cpu_idle=${cpu_idle:-0}
+        mem_free=${mem_free:-0}
+
+        local util_json="$(cat << EOF
+        {
+            "node": "${node}",
+            "cpu_idle": {
+                "Result": ${cpu_idle},
+                "Units" : "%"
+            },
+            "mem_free": {
+                "Result": ${mem_free},
+                "Units" : "kb"
+            }
+        }
+EOF
+        )"
+
+        metrics_json_add_nested_array_element "$util_json"
+
+    done 3< <(kubectl get pods --selector name=stats-pods -o json | jq -r '.items[] | "\(.metadata.name) \(.spec.nodeName)"')
+
+    metrics_json_end_nested_array "node_util"
+
+    metrics_json_close_array_element
 }
 
 init() {
@@ -97,7 +124,7 @@ init() {
 
 	# Launch our stats gathering pod
 	kubectl apply -f ${SCRIPT_PATH}/${stats_pod}.yaml
-	kubectl wait --for=condition=Ready pod "${stats_pod}"
+	kubectl rollout status --timeout=${wait_time}s daemonset/${stats_pod}
 
 	# FIXME - we should probably 'warm up' the cluster with the container image(s) we will
 	# use for testing, otherwise the download time will likely be included in the first pod
@@ -189,7 +216,7 @@ cleanup() {
 	# First try to save any results we got
 	metrics_json_end_array "BootResults"
 
-	kubectl delete pod --wait=true --timeout=${delete_wait_time}s "${stats_pod}" || true
+	kubectl delete daemonset --wait=true --timeout=${delete_wait_time}s "${stats_pod}" || true
 	local start_time=$(date +%s%N)
 	kubectl delete deployment --wait=true --timeout=${delete_wait_time}s ${deployment} || true
 	for x in $(seq 1 ${delete_wait_time}); do

--- a/metrics/scaling/stats.yaml
+++ b/metrics/scaling/stats.yaml
@@ -1,18 +1,26 @@
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: DaemonSet
 metadata:
   name: stats
 spec:
-  containers:
-    - name: stats
-      image: busybox
-      securityContext:
-        # Run a priv container so we really do measure what is happening on the
-        # host (node) system
-        privileged: true
-      command:
-          - "tail"
-          - "-f"
-          - "/dev/null"
-      stdin: true
-      tty: true
+  selector:
+    matchLabels:
+      name: stats-pods
+  template:
+    metadata:
+      labels:
+        name: stats-pods
+    spec:
+      containers:
+        - name: stats
+          image: busybox
+          securityContext:
+            # Run a priv container so we really do measure what is happening on the
+            # host (node) system
+            privileged: true
+          command:
+              - "tail"
+              - "-f"
+              - "/dev/null"
+          stdin: true
+          tty: true


### PR DESCRIPTION
This adds the stats pod via a daemonset. stats are collected for all nodes after each pod launch. The json output structure was altered to support this new data. To support the new structure, nested array support in json.bash was added. This only supports one layer of nesting. I looked at generalized nesting support, but 2D data structures in bash leaves a lot to be desired. 

The reporting in R has also been updated to support displaying cpu and memory for all nodes on a cluster for all tests being compared. The page layout was also changed to be one chart per row, rather than 2 as the charts ended up rather small for the greater detail. In the future, we'll likely want to increase the height of the rows with graphs. 