### PR TITLE
excluding NoSchedule nodes from workload calculations

### DIFF
--- a/metrics/report/report_dockerfile/scaling.R
+++ b/metrics/report/report_dockerfile/scaling.R
@@ -151,7 +151,6 @@ for (currentdir in resultdirs) {
 			cdata=cbind(cdata, count=seq_len(length(cdata[, "boot_time"])))
 			cdata=cbind(cdata, testname=rep(testname, length(cdata[, "boot_time"]) ))
 			cdata=cbind(cdata, dataset=rep(datasetname, length(cdata[, "boot_time"]) ))
-			#cdata=cbind(cdata, pndata)
 
 			# Gather our statistics
 			# '-1' containers, as the first entry should be a data capture of before

--- a/metrics/scaling/bb.json.in
+++ b/metrics/scaling/bb.json.in
@@ -22,6 +22,7 @@
                 }
             },
             "spec": {
+                "terminationGracePeriodSeconds": @GRACE@,
                 "runtimeClassName": "@RUNTIMECLASS@",
                 "automountServiceAccountToken": false,
                 "containers": [{

--- a/metrics/scaling/bb.yaml.in
+++ b/metrics/scaling/bb.yaml.in
@@ -24,6 +24,7 @@ spec:
         run: busybox
         @LABEL@: @LABELVALUE@
     spec:
+      terminationGracePeriodSeconds: @GRACE@
       runtimeClassName: @RUNTIMECLASS@
       automountServiceAccountToken: false
       containers:

--- a/metrics/scaling/k8s_scale.sh
+++ b/metrics/scaling/k8s_scale.sh
@@ -119,7 +119,7 @@ EOF
 
 	# for the first call to grab stats, there are no new pods
 	# so we need to fill in with NA (R specific value) in matching
-		# diminsion to the rest of the calls to grab_stats, so $STEP items	
+	# dimension to the rest of the calls to grab_stats, so $STEP items
 	if [[ ${#new_pods[@]} == 0 ]]; then
 		for i in $STEP; do
 			local new_pod_json="$(cat << EOF
@@ -132,7 +132,7 @@ EOF
 			metrics_json_add_nested_array_element "$new_pod_json"
 		done
 	else
-	local maxelem=$(( ${#new_pods[@]} - 1 ))
+	    local maxelem=$(( ${#new_pods[@]} - 1 ))
 		for index in $(seq 0 $maxelem); do
 			local node=$(kubectl get pod ${new_pods[$index]} -o json | jq -r '"\(.spec.nodeName)"')
 			local new_pod_json="$(cat << EOF

--- a/metrics/scaling/stats.yaml
+++ b/metrics/scaling/stats.yaml
@@ -11,6 +11,11 @@ spec:
       labels:
         name: stats-pods
     spec:
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+      terminationGracePeriodSeconds: 0
       containers:
         - name: stats
           image: busybox


### PR DESCRIPTION
Now excluding nodes with NoSchedule taints from being included in pod/CPU and pod/GB calculations.

Also added some grace period tuning. pods in the stats daemonset now shut down instantly. Grace period for pods in the workload deployment is configurable via env variable, grace.