### PR TITLE
Use directories instead of partitions for rook

### DIFF
--- a/clr-k8s-examples/7-rook/overlays/v1.0.3/kustomization.yaml
+++ b/clr-k8s-examples/7-rook/overlays/v1.0.3/kustomization.yaml
@@ -6,3 +6,6 @@ resources:
 
 patchesStrategicMerge:
   - patch_operator.yaml
+  # patches rook to use 'directories' instead of partitions.
+  # comment out to use partitions
+  - patch_cephcluster.yaml

--- a/clr-k8s-examples/7-rook/overlays/v1.0.3/patch_cephcluster.yaml
+++ b/clr-k8s-examples/7-rook/overlays/v1.0.3/patch_cephcluster.yaml
@@ -1,0 +1,9 @@
+apiVersion: ceph.rook.io/v1
+kind: CephCluster
+metadata:
+  name: rook-ceph
+  namespace: rook-ceph
+spec:
+  storage:
+    directories:
+     - path: /var/lib/rook


### PR DESCRIPTION
Fix issue where OSDs not creating without extra available partitions. Now all OSDs will be filesystem based.

Signed-off-by: Justin Scott <justin.a.scott@intel.com>