### PR TITLE
metrics: small fixes and improvements

### DIFF
--- a/metrics/lib/json.bash
+++ b/metrics/lib/json.bash
@@ -69,7 +69,7 @@ EOF
 
 	local json="$(cat << EOF
 	"test" : {
-		"runtime": "${RUNTIME}",
+		"runtime": "${RUNTIME:-default}",
 		"testname": "${TEST_NAME}"
 	}
 EOF

--- a/metrics/scaling/k8s_parallel.sh
+++ b/metrics/scaling/k8s_parallel.sh
@@ -102,6 +102,10 @@ save_stats() {
 
 	local json="$(cat << EOF
 	{
+		"date": {
+			"ns": $(date +%s%N),
+			"Date": "$(date -u +"%Y-%m-%dT%T.%3N")"
+		},
 		"n_pods": {
 			"Result": ${n_pods},
 			"Units" : "int"

--- a/metrics/scaling/k8s_parallel.sh
+++ b/metrics/scaling/k8s_parallel.sh
@@ -29,6 +29,7 @@ LABELVALUE=${LABELVALUE:-parallel}
 wait_time=${wait_time:-30}
 delete_wait_time=${delete_wait_time:-600}
 use_api=${use_api:-yes}
+grace=${grace:-30}
 
 # Set some default metrics env vars
 TEST_ARGS="runtime=${RUNTIME}"
@@ -78,6 +79,7 @@ warmup() {
 		-e "s|@DEPLOYMENT@|${deployment}|g" \
 		-e "s|@LABEL@|${LABEL}|g" \
 		-e "s|@LABELVALUE@|${LABELVALUE}|g" \
+		-e "s|@GRACE@|${grace}|g" \
 		< ${input_yaml} > ${generated_yaml}
 
 	info "Applying warmup pod"
@@ -191,6 +193,7 @@ run() {
 			-e "s|@DEPLOYMENT@|${deployment}|g" \
 			-e "s|@LABEL@|${LABEL}|g" \
 			-e "s|@LABELVALUE@|${LABELVALUE}|g" \
+			-e "s|@GRACE@|${grace}|g" \
 			< ${input_template} > ${generated_file}
 
 		info "Applying changes"
@@ -248,6 +251,8 @@ show_vars()
 	echo -e "\t\tSeconds to wait after pods ready before taking measurements"
 	echo -e "\tuse_api (${use_api})"
 	echo -e "\t\tspecify yes or no to use the API to launch pods"
+	echo -e "\tgrace (${grace})"
+	echo -e "\t\tspecify the grace period in seconds for workload pod termination"
 }
 
 help()

--- a/metrics/scaling/k8s_scale.sh
+++ b/metrics/scaling/k8s_scale.sh
@@ -46,6 +46,15 @@ grab_stats() {
 	local mem_free=()
 	info "And grab some stats"
 
+	local date_json="$(cat << EOF
+			"date": {
+				"ns": $(date +%s%N),
+				"Date": "$(date -u +"%Y-%m-%dT%T.%3N")"
+			}
+EOF
+	)"
+	metrics_json_add_array_fragment "$date_json"
+
 	local pods_json="$(cat << EOF
 			"n_pods": {
 				"Result": ${n_pods},

--- a/metrics/scaling/k8s_scale.sh
+++ b/metrics/scaling/k8s_scale.sh
@@ -141,7 +141,7 @@ EOF
 			metrics_json_add_nested_array_element "$new_pod_json"
 		done
 	else
-	    local maxelem=$(( ${#new_pods[@]} - 1 ))
+		local maxelem=$(( ${#new_pods[@]} - 1 ))
 		for index in $(seq 0 $maxelem); do
 			local node=$(kubectl get pod ${new_pods[$index]} -o json | jq -r '"\(.spec.nodeName)"')
 			local new_pod_json="$(cat << EOF


### PR DESCRIPTION
A small set of patches to:
- fix parallel test wrt grace
- add timestamps to individual metrics
- move default runtime to 'default' instead of ''
- whitespace
