### PR TITLE
Remove pinning on clearlinux version

### DIFF
--- a/clr-k8s-examples/Vagrantfile
+++ b/clr-k8s-examples/Vagrantfile
@@ -47,7 +47,6 @@ Vagrant.configure("2") do |config|
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
   config.vm.box = $box
-  config.vm.box_version = "30260"
 
   # Mount the current dir at home folder instead of default
   config.vm.synced_folder './', '/vagrant', disabled: true


### PR DESCRIPTION
While we previously had a few instabilities that pegged the version of
Clear, it is time we left it to be the bleeding edge to make sure that
the cloud-native-setup catches and reacts to latest changes on Clear.

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>