### PR TITLE
Removed vagrant box pinning

### DIFF
--- a/clr-k8s-examples/Vagrantfile
+++ b/clr-k8s-examples/Vagrantfile
@@ -13,6 +13,7 @@ $disks = 2
 $disk_prefix = File.basename(File.dirname(__FILE__), "/")
 $disk_size = "10G"
 $box = "AntonioMeireles/ClearLinux"
+$box_ver = (ENV['CLEAR_VBOX_VER'])
 File.exists?("/usr/share/qemu/OVMF.fd") ? $loader = "/usr/share/qemu/OVMF.fd" : $loader = File.join(File.dirname(__FILE__), "OVMF.fd")
 $vm_name_prefix = "clr"
 $base_ip = IPAddr.new("192.52.100.10")
@@ -47,7 +48,7 @@ Vagrant.configure("2") do |config|
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
   config.vm.box = $box
-  config.vm.box_version = "30260"
+  config.vm.box_version = $box_ver
 
   # Mount the current dir at home folder instead of default
   config.vm.synced_folder './', '/vagrant', disabled: true


### PR DESCRIPTION
Removed hardcoded vagrant box version. This change will now
allow the override of the version, or if no override is passed in
it will take the version on the system, or download the latest version.

Signed-off-by: craigsterrett <craig.sterrett@intel.com>