### PR TITLE
metrics: json: use tr for newline/whitespace conversion

### DIFF
--- a/metrics/lib/json.bash
+++ b/metrics/lib/json.bash
@@ -111,7 +111,7 @@ EOF
 	# If we have a JSON URL or host/socket pair set up, post the results there as well.
 	# Optionally compress into a single line.
 	if [[ $JSON_TX_ONELINE ]]; then
-		json="$(sed 's/[\n\t]//g' <<< ${json})"
+		json=$(tr -d '\t\n\r\f' <<< ${json})
 	fi
 
 	if [[ $JSON_HOST ]]; then


### PR DESCRIPTION
Use `tr` rather than `sed` for doing the line/whitespace conversions
on the JSON stream, if asked. Slightly more efficient, and we also drop
the wrapping ""'s, to allow the data to land in logstash without error.

Signed-off-by: Graham Whaley <graham.whaley@intel.com>