### PR TITLE
Remove possible hyphens from array index

### DIFF
--- a/metrics/scaling/k8s_scale.sh
+++ b/metrics/scaling/k8s_scale.sh
@@ -36,7 +36,7 @@ TEST_ARGS="runtime=${RUNTIME}"
 TEST_NAME="k8s scaling"
 
 declare -a new_pods
-declare -a node_basemem
+declare -A node_basemem
 
 # $1 is the launch time in seconds this pod/container took to start up.
 # $2 is the number of pod/containers under test


### PR DESCRIPTION
bash arrays don't handle hyphens in the index as it treats
a name like "azure-east-1" as 0-0-1, so remove any hyphens in the
node name, will work as long as hyphens aren't the only difference
in node names

Fixes #163 