### PR TITLE
Fixes no_proxy issues with Vagrant file

### DIFF
--- a/clr-k8s-examples/Vagrantfile
+++ b/clr-k8s-examples/Vagrantfile
@@ -18,7 +18,7 @@ File.exists?("/usr/share/qemu/OVMF.fd") ? $loader = "/usr/share/qemu/OVMF.fd" : 
 $vm_name_prefix = "clr"
 $base_ip = IPAddr.new("192.52.100.10")
 $hosts = {}
-$proxy_ip_list = ""
+$proxy_ip_list = "192.168.121.0/24"
 $driveletters = ('a'..'z').to_a
 $setup_fc = true ? (['true', '1'].include? ENV['SETUP_FC'].to_s) : false
 $runner = ENV.has_key?('RUNNER') ? ENV['RUNNER'].to_s : "containerd".to_s
@@ -49,6 +49,12 @@ Vagrant.configure("2") do |config|
   # boxes at https://vagrantcloud.com/search.
   config.vm.box = $box
   config.vm.box_version = $box_ver
+
+  #Reboot at the end to pick up kernal updates
+  config.trigger.after [:provision] do |t|
+    t.name = "Reboot after provisioning"
+    t.run = { :inline => "vagrant reload" }
+  end
 
   # Mount the current dir at home folder instead of default
   config.vm.synced_folder './', '/vagrant', disabled: true
@@ -82,7 +88,15 @@ Vagrant.configure("2") do |config|
         if Vagrant.has_plugin?("vagrant-proxyconf")
           c.proxy.http = (ENV['http_proxy']||ENV['HTTP_PROXY'])
           c.proxy.https = (ENV['https_proxy']||ENV['HTTPS_PROXY'])
-          c.proxy.no_proxy =  (ENV['no_proxy']+"#{$proxy_ip_list}" || ENV['NO_PROXY']+"#{$proxy_ip_list}" || "localhost,127.0.0.1,172.16.10.10#{$proxy_ip_list}")
+          if ENV['no_proxy'] || ENV['NO_PROXY']
+            if ENV['no_proxy']
+              c.proxy.no_proxy =  (ENV['no_proxy']+","+"#{$proxy_ip_list}")
+            else
+              c.proxy.no_proxy =  (ENV['NO_PROXY']+","+"#{$proxy_ip_list}")
+            end
+          else
+            c.proxy.no_proxy =  "localhost,127.0.0.1,172.16.10.10,#{$proxy_ip_list}"
+          end
         end
       end
       c.vm.provision "shell", privileged: false, path: "setup_system.sh", env: {"RUNNER" => $runner}


### PR DESCRIPTION
Vagrant file blows up if http_proxy is set but no_proxy is not set. This
was discovered during the testing of the initial patch which was to add
the default CIDR for Vagrant to the no_proxy settings.

Closes issue #136 

Signed-off-by: craigsterrett <craig.sterrett@intel.com>