### PR TITLE
adding detailed instructions for vagrant setup on clear linux

### DIFF
--- a/clr-k8s-examples/vagrant.md
+++ b/clr-k8s-examples/vagrant.md
@@ -34,16 +34,15 @@ Note, vagrant installation steps were derived from:
 
 ## Install vagrant on Clear Linux
 
-Install unzip bundle using the following command, since [`vagrant.sh`](https://github.com/AntonioMeireles/ClearLinux-packer/blob/master/extras/clearlinux/setup/vagrant.sh) requires it.
-```bash
-sudo swupd bundle-add unzip
-```
-Install rsync bundle using the following command, since [`Vagrantfile`](https://github.com/clearlinux/cloud-native-setup/blob/master/clr-k8s-examples/Vagrantfile) requires it.
-```bash
-sudo swupd bundle-add rsync
-```
-
 On Clear Linux, run these commands
+```bash
+sudo swupd update
+```
+Make sure all the prerequisite packages are installed
+```bash
+sudo swupd bundle-add unzip rsync wget kvm-host
+```
+Now, run the following scripts
 ```bash
 wget https://raw.githubusercontent.com/AntonioMeireles/ClearLinux-packer/master/extras/clearlinux/setup/libvirtd.sh
 chmod +x libvirtd.sh
@@ -56,7 +55,6 @@ Check if vagrant is installed successfully
 ```bash
 vagrant --version
 ```
-
 Run vagrant
 ```bash
 vagrant up --provider=libvirt

--- a/clr-k8s-examples/vagrant.md
+++ b/clr-k8s-examples/vagrant.md
@@ -34,12 +34,21 @@ Note, vagrant installation steps were derived from:
 
 ## Install vagrant on Clear Linux
 
+Install unzip bundle using the following command, since [`vagrant.sh`](https://github.com/AntonioMeireles/ClearLinux-packer/blob/master/extras/clearlinux/setup/vagrant.sh) requires it.
+```bash
+sudo swupd bundle-add unzip
+```
+Install rsync bundle using the following command, since [`Vagrantfile`](https://github.com/clearlinux/cloud-native-setup/blob/master/clr-k8s-examples/Vagrantfile) requires it.
+```bash
+sudo swupd bundle-add rsync
+```
+
 On Clear Linux, run these commands
 ```bash
-sudo wget https://raw.githubusercontent.com/AntonioMeireles/ClearLinux-packer/master/extras/clearlinux/setup/libvirtd.sh
+wget https://raw.githubusercontent.com/AntonioMeireles/ClearLinux-packer/master/extras/clearlinux/setup/libvirtd.sh
 chmod +x libvirtd.sh
 ./libvirtd.sh
-sudo wget https://raw.githubusercontent.com/AntonioMeireles/ClearLinux-packer/master/extras/clearlinux/setup/vagrant.sh
+wget https://raw.githubusercontent.com/AntonioMeireles/ClearLinux-packer/master/extras/clearlinux/setup/vagrant.sh
 chmod +x vagrant.sh
 ./vagrant.sh
 ```
@@ -47,7 +56,12 @@ Check if vagrant is installed successfully
 ```bash
 vagrant --version
 ```
+
 Run vagrant
 ```bash
 vagrant up --provider=libvirt
+```
+You can check the vagrant status using the following command
+```bash
+vagrant status
 ```


### PR DESCRIPTION
Added command for installing unzip bundle since vagrant.sh requires unzip, else it will error out. Similarly, added command for installing rsync bundle, since Vagrantfile requires it. These bundles need to be added explicitly on some clear images. Also, removed the sudo, since running as normal user works fine.