### PR TITLE
Setting the RUNNER to use crio

### DIFF
--- a/clr-k8s-examples/README.md
+++ b/clr-k8s-examples/README.md
@@ -35,8 +35,8 @@ This script ensures the following
 * Ensures all the dependencies are loaded on boot (kernel modules)
 
 > NOTE: This step is done automatically if using vagrant. The setup_system.sh script uses
-the runtime specified in the RUNNER environment variable and defaults to crio. To use the
-containerd runtime, set the RUNNER environment variable to containerd.
+the runtime specified in the RUNNER environment variable and defaults to `crio`. To use the
+`containerd` runtime, set the RUNNER environment variable to `containerd`.
 
 ### Configuration for high numbers of pods per node
 

--- a/clr-k8s-examples/README.md
+++ b/clr-k8s-examples/README.md
@@ -34,7 +34,9 @@ This script ensures the following
 * Customizes the system to ensure correct defaults are setup (IP Forwarding, Swap off,...)
 * Ensures all the dependencies are loaded on boot (kernel modules)
 
-> NOTE: This step is done automatically if using vagrant.
+> NOTE: This step is done automatically if using vagrant. When running this script, by default
+the RUNNER is set to use crio, if need to be changed make sure to specify the RUNNER to be 
+either crio/containerd. 
 
 ### Configuration for high numbers of pods per node
 

--- a/clr-k8s-examples/README.md
+++ b/clr-k8s-examples/README.md
@@ -34,9 +34,9 @@ This script ensures the following
 * Customizes the system to ensure correct defaults are setup (IP Forwarding, Swap off,...)
 * Ensures all the dependencies are loaded on boot (kernel modules)
 
-> NOTE: This step is done automatically if using vagrant. When running this script, by default
-the RUNNER is set to use crio, if need to be changed make sure to specify the RUNNER to be 
-either crio/containerd. 
+> NOTE: This step is done automatically if using vagrant. The setup_system.sh script uses
+the runtime specified in the RUNNER environment variable and defaults to crio. To use the
+containerd runtime, set the RUNNER environment variable to containerd.
 
 ### Configuration for high numbers of pods per node
 

--- a/clr-k8s-examples/setup_system.sh
+++ b/clr-k8s-examples/setup_system.sh
@@ -10,7 +10,7 @@ HIGH_POD_COUNT=${HIGH_POD_COUNT:-""}
 # set no proxy
 ADD_NO_PROXY="10.244.0.0/16,10.96.0.0/12"
 ADD_NO_PROXY+=",$(hostname -I | sed 's/[[:space:]]/,/g')"
-: "${RUNNER:=containerd}"
+: "${RUNNER:=crio}"
 
 # update os version
 function upate_os_version() {


### PR DESCRIPTION
This change helps with setting up the RUNNER to use crio
by default instead of using containerd. If the user wants
to use containerd, they need to specify when running the
setup_system script.

Signed-off: Syed <syed.ahsan.shamim.zaidi@intel.com>

#176 