### PR TITLE
Update ingress-nginx to v0.25.1

### DIFF
--- a/clr-k8s-examples/5-ingres-lb/overlays/nginx-0.25.1/kustomization.yaml
+++ b/clr-k8s-examples/5-ingres-lb/overlays/nginx-0.25.1/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - ingress-nginx/deploy/static/mandatory.yaml
+  - ingress-nginx/deploy/static/provider/baremetal/service-nodeport.yaml
+

--- a/clr-k8s-examples/create_stack.sh
+++ b/clr-k8s-examples/create_stack.sh
@@ -181,8 +181,9 @@ function dashboard() {
 	kubectl apply -k "${DASHBOARD_DIR}/overlays/${DASHBOARD_VER}"
 }
 
+
 function ingres() {
-	INGRES_VER=${1:-nginx-0.25.0}
+	INGRES_VER=${1:-nginx-0.25.1}
 	INGRES_URL="https://github.com/kubernetes/ingress-nginx.git"
 	INGRES_DIR="5-ingres-lb"
 	get_repo "${INGRES_URL}" "${INGRES_DIR}/overlays/${INGRES_VER}"


### PR DESCRIPTION
Patches HTTP2 CVEs as detailed here http://nginx.org/en/security_advisories.html

Signed-off-by: Justin Scott <justin.a.scott@intel.com>