### PR TITLE
Adding Cert sans to kubeadm config

### DIFF
--- a/clr-k8s-examples/create_stack.sh
+++ b/clr-k8s-examples/create_stack.sh
@@ -54,8 +54,12 @@ function cluster_init() {
 	if [[ -n "$K8S_VER" && $(grep -c kubernetesVersion ./kubeadm.yaml) -eq 0 ]]; then
 		sed -i "s/ClusterConfiguration/ClusterConfiguration\nkubernetesVersion: ${K8S_VER}/g" ./kubeadm.yaml
 	fi
-	if ! [ -z "${CERT_SANS}" ]; then
-		sed -i "/ClusterConfiguration/a apiServer:\\n  certSANs:"  ./kubeadm.yaml
+	if [[ -n "$CERT_SANS" ]]; then
+		if [[ $(grep -c certSANs ./kubeadm.yaml) -gt 0 ]]; then
+			sed -i '/certSANs/,/[a-zA-Z]*:/{//!d}' ./kubeadm.yaml
+		else
+			sed -i "/ClusterConfiguration/a apiServer:\\n  certSANs:"  ./kubeadm.yaml
+		fi
 		for CERT_SAN in ${CERT_SANS[@]}; do
 			sed -i "/certSANs/a \ \ - ${CERT_SAN}" ./kubeadm.yaml
 		 done

--- a/clr-k8s-examples/create_stack.sh
+++ b/clr-k8s-examples/create_stack.sh
@@ -12,6 +12,7 @@ CUR_DIR=$(pwd)
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 : ${TOKEN:=}
 : ${MASTER_IP:=}
+: ${CERT_SANS:=}
 HIGH_POD_COUNT=${HIGH_POD_COUNT:-""}
 
 # versions
@@ -53,7 +54,12 @@ function cluster_init() {
 	if [[ -n "$K8S_VER" && $(grep -c kubernetesVersion ./kubeadm.yaml) -eq 0 ]]; then
 		sed -i "s/ClusterConfiguration/ClusterConfiguration\nkubernetesVersion: ${K8S_VER}/g" ./kubeadm.yaml
 	fi
-	# Config patches
+	if ! [ -z "${CERT_SANS}" ]; then
+		sed -i "/ClusterConfiguration/a apiServer:\\n  certSANs:"  ./kubeadm.yaml
+		for CERT_SAN in ${CERT_SANS[@]}; do
+			sed -i "/certSANs/a \ \ - ${CERT_SAN}" ./kubeadm.yaml
+		 done
+	fi
 	if [[ -n "${HIGH_POD_COUNT}" ]]; then
 		# increase limits in kubelet
 		sed -i "/KubeletConfiguration/a maxOpenFiles\: 1048576" ./kubeadm.yaml


### PR DESCRIPTION
When we are using instances in the public cloud, such amazon or azure, we need a way to connect to the public k8s cluster with the public ip or the public name, with this addition we are supporting the ability to add those public values into the k8s certificates in order to can connect from anywhere not only from the private cluster subnet.

example: 

```
export CERT_SANS="34.221.115.244 ec2-34-221-115-244.us-west-2.compute.amazonaws.com"

 ./create_stack.sh  init
```

```
$kubectl cluster-info
Kubernetes master is running at https://ec2-34-221-115-244.us-west-2.compute.amazonaws.com:6443
KubeDNS is running at https://ec2-34-221-115-244.us-west-2.compute.amazonaws.com:6443/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
```