### PR TITLE
Vagrant Libvirt Instructions update

### DIFF
--- a/clr-k8s-examples/vagrant.md
+++ b/clr-k8s-examples/vagrant.md
@@ -21,6 +21,10 @@ Download the latest Debian package from https://www.vagrantup.com/downloads.html
 sudo dpkg -i vagrant_${VER}_x86_64.deb
 vagrant plugin install vagrant-libvirt
 ```
+Make sure to add the user to the default group
+```bash
+usermod --append --groups libvirt `whoami`
+```
 
 Run vagrant
 ```bash

--- a/clr-k8s-examples/vagrant.md
+++ b/clr-k8s-examples/vagrant.md
@@ -19,11 +19,16 @@ echo "vhost_net" | sudo tee -a /etc/modules
 Download the latest Debian package from https://www.vagrantup.com/downloads.html and install it followed by vagrant-libvirt
 ```bash
 sudo dpkg -i vagrant_${VER}_x86_64.deb
-sudo vagrant plugin install vagrant-libvirt
+vagrant plugin install vagrant-libvirt
 ```
+Make sure to add the user to the default group
+```bash
+usermod --append --groups libvirt `whoami`
+```
+
 Run vagrant
 ```bash
-sudo vagrant up --provider=libvirt
+vagrant up --provider=libvirt
 ```
 
 Note, vagrant installation steps were derived from:

--- a/clr-k8s-examples/vagrant.md
+++ b/clr-k8s-examples/vagrant.md
@@ -21,10 +21,6 @@ Download the latest Debian package from https://www.vagrantup.com/downloads.html
 sudo dpkg -i vagrant_${VER}_x86_64.deb
 vagrant plugin install vagrant-libvirt
 ```
-Make sure to add the user to the default group
-```bash
-usermod --append --groups libvirt `whoami`
-```
 
 Run vagrant
 ```bash


### PR DESCRIPTION
This patch adds the users to the default group so we dont
have to use sudo to start the vagrant, as using sudo is not
the most optimal route for gems to be properly configured.

Signed-off: Syed Ahsan <syed.ahsan.shamim.zaidi@intel.com>