### PR TITLE
kubelet: use systemd cgroup driver

### DIFF
--- a/clr-k8s-examples/kubeadm.yaml
+++ b/clr-k8s-examples/kubeadm.yaml
@@ -3,6 +3,7 @@ kind: InitConfiguration
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+cgroupDriver: systemd
 # Allowing for CPU pinning and isolation in case of guaranteed QoS class
 cpuManagerPolicy: static
 systemReserved:


### PR DESCRIPTION
Fixes: clearlinux/distribution/issues/1267 (partial)

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>