### PR TITLE
Typo in vagrant instruction

### DIFF
--- a/clr-k8s-examples/vagrant.md
+++ b/clr-k8s-examples/vagrant.md
@@ -26,9 +26,9 @@ Run vagrant
 sudo vagrant up --provider=libvirt
 ```
 
-Note, in order to spin up vagrant to use different CPU and MEMORY for individual VM's:
+Note, in order to spin up vagrant to use different CPUS and MEMORY for individual VM's:
 ```bash
-CPU=4 MEMORY=8096 vagrant up clr-01 --provider=libvirt
+CPUS=4 MEMORY=8096 vagrant up clr-01 --provider=libvirt
 ```
 
 Note, vagrant installation steps were derived from:


### PR DESCRIPTION
#205 This patch fixes the typo in vagrant instructions, it should be
CPUS.

Signed-off: Syed Ahsan <syed.ahsan.shamim.zaidi@intel.com>