### PR TITLE
[WIP] Add number of sockets per node to be captured in output result.

### DIFF
--- a/metrics/lib/json.bash
+++ b/metrics/lib/json.bash
@@ -56,7 +56,7 @@ EOF
 	$(kubectl get nodes -o=json)
 EOF
 )"
-	metrics_json_add_fragment "$json"
+        metrics_json_add_fragment "$json"
 
 	local json="$(cat << EOF
 	"date" : {

--- a/metrics/scaling/common.bash
+++ b/metrics/scaling/common.bash
@@ -28,3 +28,4 @@ grace=${grace:-30}
 declare -a new_pods
 declare -A node_basemem
 declare -A node_baseinode
+declare -A node_numsockets


### PR DESCRIPTION
The proposed changes will write the number of sockets to be included in the `node_util `section of output results same as memory used within the node.

I'm aware that this is a repetitive value within the result file (same as others) and for which:

- can be handle at reporting phase to not to repite such result in final report.
- to be avoided I could write a similar function as `grab_stats()` to gather the number of sockets per node, which will require to launch pods as nodes we have in the Kubernetes cluster to ensure that each pod gets assigned to all available nodes and get the number of sockets trough `kubectl exec` command, and the final result can be added at the end of `k8s-scaling` result section.
- restructure the output result file to avoid repetitive data in general, this will impact the reporting phase too and thus reporting will change too.

I'm more keen to option 1 and 3, what do you think?