### PR TITLE
No need of launching kubelet before kubeadm init/join

### DIFF
--- a/clr-k8s-examples/setup_system.sh
+++ b/clr-k8s-examples/setup_system.sh
@@ -127,8 +127,7 @@ function daemon_reload() {
 function enable_kubelet_runner() {
 	# This will fail at this point, but puts it into a retry loop that
 	# will therefore startup later once we have configured with kubeadm.
-	echo "The following kubelet command may complain... it is not an error"
-	sudo systemctl enable --now kubelet $RUNNER || true
+	sudo systemctl enable kubelet $RUNNER || true
 }
 
 # ensure that the system is ready without requiring a reboot
@@ -212,5 +211,3 @@ setup_proxy
 sudo systemctl daemon-reload
 # restart runner
 sudo systemctl restart $RUNNER || true
-# restart kubelet
-sudo systemctl restart kubelet || true


### PR DESCRIPTION
There is no need of launching kubelet before kubeadm, giving a confusing launch fail warning message, since kubelet will startup later once we have configured with kubeadm. This PR fixes issue #127 . 

Closing #138 

Signed-off-by: Khanak Nangia khanak.nangia@intel.com