### PR TITLE
Add extra table about node information into PDF report.

### DIFF
--- a/metrics/report/report_dockerfile/metrics_report.Rmd
+++ b/metrics/report/report_dockerfile/metrics_report.Rmd
@@ -47,3 +47,13 @@ in the test results files.
 ```{r dut, echo=FALSE, fig.cap="System configuration details"}
 source('dut-details.R')
 ```
+
+\pagebreak
+
+# Test setup node details
+
+This table describes node details within the Kubernetes cluster that have been used for test.
+
+```{r node, echo=FALSE, fig.cap="Node information within Kubernetes cluster"}
+source('node-info.R')
+```

--- a/metrics/report/report_dockerfile/node-info.R
+++ b/metrics/report/report_dockerfile/node-info.R
@@ -1,0 +1,95 @@
+#!/usr/bin/env Rscript
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Display details for the 'Nodes within Kubernetes cluster'.
+
+suppressMessages(suppressWarnings(library(tidyr)))      # for gather().
+library(tibble)
+suppressMessages(suppressWarnings(library(plyr)))       # rbind.fill
+                                                        # So we can plot multiple graphs
+library(gridExtra)                                      # together.
+suppressMessages(suppressWarnings(library(ggpubr)))     # for ggtexttable.
+suppressMessages(library(jsonlite))                     # to load the data.
+
+# A list of all the known results files we might find the information inside.
+resultsfiles=c(
+	       "k8s-scaling.json"
+	       )
+
+stats=c()
+stats_names=c()
+max_char_name_node=18
+
+# list for each dirstats
+dirstats_list=list()
+j=1
+
+# For each set of results
+for (currentdir in resultdirs) {
+	dirstats=c()
+	for (resultsfile in resultsfiles) {
+		fname=paste(inputdir, currentdir, resultsfile, sep="/")
+		if ( !file.exists(fname)) {
+			next
+		}
+
+		# Derive the name from the test result dirname
+		datasetname=basename(currentdir)
+
+		# Import the data
+		fdata=fromJSON(fname)
+
+		if (length(fdata$'kubectl-version') != 0 ) {
+			numnodes= nrow(fdata$'kubectl-get-nodes'$items)
+			for (i in 1:numnodes) {
+				node_i=fdata$'kubectl-get-nodes'$items[i,]
+				node_info=fdata$'socketsPerNode'[i,]
+
+				# Substring node name so it fits properly into final table
+				node_name=node_i$metadata$name
+				if ( nchar(node_name) >= max_char_name_node) {
+					dirstats=tibble("Node \nname"=as.character(substring(node_name, 1, max_char_name_node)))
+				} else {
+					dirstats=tibble("Node \nname"=as.character(node_name))
+				}
+
+				dirstats=cbind(dirstats, "CPUs"=as.character(node_i$status$capacity$cpu))
+				dirstats=cbind(dirstats, "Memory"=as.character(node_i$status$capacity$memory))
+				dirstats=cbind(dirstats, "Max \nPods"=as.character(node_i$status$capacity$pods))
+				dirstats=cbind(dirstats, "Count \nsockets"=as.character(node_info$num_sockets))
+				dirstats=cbind(dirstats, "Have \nhypervisor"=as.character(node_info$hypervisor))
+
+				dirstats=cbind(dirstats, "kernel"=as.character(node_i$status$nodeInfo$kernelVersion))
+				dirstats=cbind(dirstats, "OS"=as.character(node_i$status$nodeInfo$osImage))
+				dirstats=cbind(dirstats, "Test"=as.character(datasetname))
+
+				dirstats_list[[j]]=dirstats
+				j=j+1
+			}
+			complete_data = do.call(rbind, dirstats_list)
+		}
+	}
+
+	if ( length(complete_data) == 0 ) {
+		warning(paste("No valid data found for directory ", currentdir))
+	}
+
+	# use plyr rbind.fill so we can combine disparate version info frames
+	stats=rbind.fill(stats, complete_data)
+	stats_names=rbind(stats_names, datasetname)
+}
+# Build us a text table of numerical results
+# Set up as left hand justify, so the node data indent renders.
+tablefontsize=8
+tbody.style = tbody_style(hjust=0, x=0.1, size=tablefontsize)
+stats_plot = suppressWarnings(ggtexttable(data.frame(complete_data, check.names=FALSE),
+					  theme=ttheme(base_size=tablefontsize, tbody.style=tbody.style),
+					  rows=NULL))
+
+# It may seem odd doing a grid of 1x1, but it should ensure we get a uniform format and
+# layout to match the other charts and tables in the report.
+master_plot = grid.arrange(stats_plot,
+			   nrow=1,
+			   ncol=1 )


### PR DESCRIPTION
**What**
A final table report gets added into the PDF report for node information details per node.

**Tests**
The changes where tested using two different results, following the next structure:
```
$ tree metrics/results/
metrics/results/
├── Env.R
├── scaling
│   └── k8s-scaling.json
└── scaling-vms
    └── k8s-scaling.json
``` 
The final look for the created tables is shown below 🎉 
![node-1](https://user-images.githubusercontent.com/21090606/66961058-6d581c00-f033-11e9-8aa7-8514c1e975ab.png)
And the final PDF report is attached too.
[metrics_report.pdf](https://github.com/clearlinux/cloud-native-setup/files/3736493/metrics_report.pdf)
