### PR TITLE
Fix partly #225.

### DIFF
--- a/metrics/report/report_dockerfile/dut-details.R
+++ b/metrics/report/report_dockerfile/dut-details.R
@@ -77,6 +77,7 @@ for (currentdir in resultdirs) {
 
 	if ( length(dirstats) == 0 ) {
 		warning(paste("No valid data found for directory ", currentdir))
+		break
 	}
 
 	# use plyr rbind.fill so we can combine disparate version info frames

--- a/metrics/report/report_dockerfile/tidy_scaling.R
+++ b/metrics/report/report_dockerfile/tidy_scaling.R
@@ -43,13 +43,19 @@ for (currentdir in resultdirs) {
 				next
 			}
 
+			# Check if filename follows the hard-coded test name
+			shortname=substr(ffound, 1, nchar(ffound)-nchar(".json"))
+			if ( substr(testname, 1, nchar(testname)-nchar(".*")) != shortname) {
+				warning(paste("Result file name does not match with test name: ", shortname))
+				break
+			}
+
 			# Derive the name from the test result dirname
 			datasetname=basename(currentdir)
 
 			# Import the data
 			fdata=fromJSON(fname)
 			# De-nest the test name specific data
-			shortname=substr(ffound, 1, nchar(ffound)-nchar(".json"))
 			fdata=fdata[[shortname]]
 			testname=datasetname
 
@@ -195,8 +201,12 @@ for (currentdir in resultdirs) {
 		# And collect up our rows into our global table of all results
 		# These two tables *should* be the source of all the data we need to
 		# process and plot (apart from the stats....)
-		bootdata=rbind(bootdata, local_bootdata, make.row.names=FALSE)
-		nodedata=rbind(nodedata, local_nodedata, make.row.names=FALSE)
+		if ( exists("local_bootdata") ) {
+			bootdata=rbind(bootdata, local_bootdata, make.row.names=FALSE)
+			nodedata=rbind(nodedata, local_nodedata, make.row.names=FALSE)
+		 } else {
+			 warning(paste("Could not able to create report for: ", ffound))
+		}
 	}
 }
 


### PR DESCRIPTION
**What**
Generate a final report for `k8s-scaling.json` result in different subdirectories which follows the current hard-coded test name `k8s-scaling`.

**Edited files:**
- `report/report_dockerfile/tidy_scaling.R`
- `report/report_dockerfile/dut-details.R`

**Testing done**:
Having the next results structure:
```
$ tree results/
results/
├── Env.R
├── scaling
│   └── k8s-scaling.json
└── scaling2
    └── k8s-scaling2.json

2 directories, 3 files
```
the `k8s-scaling2.json` does not follow the hard-coded test name, and only for it a warning message will be displayed in the final report, see report attached.
[metrics_report.pdf](https://github.com/clearlinux/cloud-native-setup/files/3745773/metrics_report.pdf)
