### PR TITLE
Correct compute of CPU usage.

### DIFF
--- a/metrics/report/report_dockerfile/tidy_scaling.R
+++ b/metrics/report/report_dockerfile/tidy_scaling.R
@@ -140,7 +140,7 @@ for (currentdir in resultdirs) {
 					next
 				}
 				memtotal = memtotal + thisnode[nrow(thisnode),]$mem_used
-				cpuused = thisnode[1,]$idle - thisnode[nrow(thisnode),]$idle
+				cpuused = thisnode[nrow(thisnode),]$idle - thisnode[1,]$idle
 				cputotal = cputotal + cpuused
 				inodetotal = inodetotal + thisnode[nrow(thisnode),]$inode_used
 			}


### PR DESCRIPTION
**What**
Fix for negative entries reported at System CPU usage graph (see #230 ), which takes into account the absolute difference between first and last entry for `idle` data.

**Testing**
Having the next result entries:
```
$ tree results/
results/
├── Env.R
├── scaling-P10
│   └── k8s-scaling.json
└── scaling-P20
    └── k8s-scaling.json

2 directories, 3 files
```

The report execution generates the next graph for System CPI usage:
![scaling-2](https://user-images.githubusercontent.com/21090606/67244752-05814700-f420-11e9-86f3-4b8efd2cea28.png)
As it can be see, the scaling execution can start with a higher CPU usage, maybe for previous tests or it's is simply the current state for the nodes, or viceversa, that's why to consider the absolute difference instead of a simple subtraction operation. 
The complete generated report is attached too ([metrics_report.pdf](https://github.com/clearlinux/cloud-native-setup/files/3752985/metrics_report.pdf))
