### PR TITLE
Added .svc to no_proxy

### DIFF
--- a/clr-k8s-examples/setup_system.sh
+++ b/clr-k8s-examples/setup_system.sh
@@ -8,7 +8,7 @@ CLRK8S_OS=${CLRK8S_OS:-""}
 HIGH_POD_COUNT=${HIGH_POD_COUNT:-""}
 
 # set no proxy
-ADD_NO_PROXY="10.244.0.0/16,10.96.0.0/12"
+ADD_NO_PROXY=".svc,10.244.0.0/16,10.96.0.0/12"
 ADD_NO_PROXY+=",$(hostname -I | sed 's/[[:space:]]/,/g')"
 : "${RUNNER:=crio}"
 


### PR DESCRIPTION
Added .svc to the no_proxy in setup_system.sh to keep Kubernetes service
requests from being routed to the proxy. This fixes and issue that
Humberto was seeing in his testing.

Signed-off-by: Craig Sterrett <craig.sterrett@intel.com>