### PR TITLE
Increasing the CPUS and MEMORY default value for vagrant VMs

### DIFF
--- a/clr-k8s-examples/README.md
+++ b/clr-k8s-examples/README.md
@@ -14,7 +14,7 @@ Follow instructions in the [Vagrant docs](https://www.vagrantup.com/intro/gettin
 Or, follow our [detailed steps](vagrant.md)
 
 Now you have a 3 node cluster up and running. Each of them have 2 vCPU, 4GB Memory, 2x10GB disks, 1 additional private network.
-Customize the setup using environment variables. E.g., `NODES=1 MEMORY=8192 CPUS=8 vagrant up --provider=libvirt`
+Customize the setup using environment variables. E.g., `NODES=2 MEMORY=16384 CPUS=8 vagrant up --provider=libvirt`
 
 To login to the master node and change to this directory
 

--- a/clr-k8s-examples/Vagrantfile
+++ b/clr-k8s-examples/Vagrantfile
@@ -6,8 +6,8 @@ require 'ipaddr'
 require 'securerandom'
 
 $num_instances = (ENV['NODES'] || 3).to_i
-$cpus = (ENV['CPUS'] || 2).to_i
-$memory = (ENV['MEMORY'] || 4096).to_i
+$cpus = (ENV['CPUS'] || 4).to_i
+$memory = (ENV['MEMORY'] || 8192).to_i
 $disks = 2
 # Using folder prefix instead of uuid until vagrant-libvirt fixes disk cleanup
 $disk_prefix = File.basename(File.dirname(__FILE__), "/")


### PR DESCRIPTION
Updating the default value to 4 CPUS and 8G MEMORY for vagrant VMs. Since running setup_system.sh and create_Stack.sh all is resource intensive and vagrant VMs keep shutting off with less resources.