### PR TITLE
updating readme with increased CPUS and MEMORY value for vagrant VMs

### DIFF
--- a/clr-k8s-examples/README.md
+++ b/clr-k8s-examples/README.md
@@ -13,7 +13,7 @@ Follow instructions in the [Vagrant docs](https://www.vagrantup.com/intro/gettin
 
 Or, follow our [detailed steps](vagrant.md)
 
-Now you have a 3 node cluster up and running. Each of them have 2 vCPU, 4GB Memory, 2x10GB disks, 1 additional private network.
+Now you have a 3 node cluster up and running. Each of them have 4 vCPU, 8GB Memory, 2x10GB disks, 1 additional private network.
 Customize the setup using environment variables. E.g., `NODES=2 MEMORY=16384 CPUS=8 vagrant up --provider=libvirt`
 
 To login to the master node and change to this directory


### PR DESCRIPTION
With reference to #240 , updating README.md with new increased default values of CPUS and MEMORY for Vagrant VMs.

Signed-off-by: Khanak Nangia khanak.nangia@intel.com