### PR TITLE
Disable git checkout advice in create_stack.sh

### DIFF
--- a/clr-k8s-examples/create_stack.sh
+++ b/clr-k8s-examples/create_stack.sh
@@ -341,7 +341,7 @@ function set_repo_version() {
 	pushd "$(pwd)"
 	cd "${path}"
 	git fetch origin "${ver}"
-	git checkout "${ver}"
+	git -c advice.detachedHead=false checkout "${ver}"
 	popd
 
 }


### PR DESCRIPTION
This PR disables the git advice message seen for
each component as its installed.

Signed-off-by: Justin Scott <justin.a.scott@gmail.com>