### PR TITLE
Add CLRK8S_CLR_VER to setup_system.sh

### DIFF
--- a/clr-k8s-examples/README.md
+++ b/clr-k8s-examples/README.md
@@ -38,6 +38,11 @@ This script ensures the following
 script uses the runtime specified in the `RUNNER` environment variable and defaults to `crio`. To use the
 `containerd` runtime, set the `RUNNER` environment variable to `containerd`.
 
+### Specify a version of Clear Linux
+
+To specify a particular version of Clear Linux to use, set the CLRK8S_CLR_VER environment variable to the desired
+version before starting setup_system.sh (e.g. `CLRK8S_CLR_VER=31400 ./setup_system.sh`)
+
 ### Configuration for high numbers of pods per node
 
 In order to enable running greater than 110 pods per node, set the environment

--- a/clr-k8s-examples/setup_system.sh
+++ b/clr-k8s-examples/setup_system.sh
@@ -5,6 +5,7 @@ set -o nounset
 
 # global vars
 CLRK8S_OS=${CLRK8S_OS:-""}
+CLR_VER=${CLRK8S_CLR_VER:-""}
 HIGH_POD_COUNT=${HIGH_POD_COUNT:-""}
 
 # set no proxy
@@ -14,6 +15,11 @@ ADD_NO_PROXY+=",$(hostname -I | sed 's/[[:space:]]/,/g')"
 
 # update os version
 function upate_os_version() {
+	if [[ -n "${CLR_VER}" ]];
+	then
+		sudo swupd repair -m "${CLR_VER}" --picky
+		return
+	fi
 	sudo swupd update
 }
 


### PR DESCRIPTION
This adds ability to upgrade/downgrade to desired Clear version.
The default behavior remains unchanged (auto updating to latest)

Signed-off-by: Justin Scott <justin.a.scott@intel.com>