### PR TITLE
Specify hostname for file name for collectd

### DIFF
--- a/metrics/collectd/collectd.conf
+++ b/metrics/collectd/collectd.conf
@@ -9,6 +9,8 @@ LoadPlugin memory
 LoadPlugin cpufreq
 LoadPlugin df
 
+Hostname localhost
+
 <Plugin "cpu">
     ReportByCpu true
     ReportByState true


### PR DESCRIPTION
On some machines the value for hostname, that is used in naming
the csv directory, isn't always determined by collectd to be
localhost. The scaling code assumes it will always be localhost.

This patch specifies the hostname to be localhost.

Signed-off-by: David Lyle <dklyle0@gmail.com>