### PR TITLE
fixing makereport container build

### DIFF
--- a/metrics/report/report_dockerfile/Dockerfile
+++ b/metrics/report/report_dockerfile/Dockerfile
@@ -13,7 +13,7 @@
 # We would have used the 'verse' base, that already has some of the docs processing
 # installed, but I could not figure out how to add in the extra bits we needed to
 # the lite tex version is uses.
-FROM rocker/tidyverse
+FROM rocker/tidyverse:latest
 
 # Version of the Dockerfile
 LABEL DOCKERFILE_VERSION="1.0"


### PR DESCRIPTION
A recent change to debian apt repositories led to build errors
for the report container. The error was around stretch release
files. The container image we are based on published an update
which fixes this error. This patch updates to use :latest to
avoid errors when building.

Signed-off-by: David Lyle <dklyle0@gmail.com>