### PR TITLE
support older network interface naming

### DIFF
--- a/metrics/collectd/collectd.conf
+++ b/metrics/collectd/collectd.conf
@@ -23,6 +23,7 @@ LoadPlugin df
     Interface "/^ens/"
     Interface "/^enp/"
     Interface "/^em/"
+    Interface "/^eth/"
     IgnoreSelected false
 </Plugin>
 <Plugin "aggregation">


### PR DESCRIPTION
KIND uses the older network interface naming standard. Other
operating system images may as well. Adding support for 'eth'
network interface naming prefix.

Closes #257 

Signed-off-by: David Lyle <dklyle0@gmail.com>