### PR TITLE
devmapper: update to be functional, usable

### DIFF
--- a/clr-k8s-examples/containerd_devmapper_setup.sh
+++ b/clr-k8s-examples/containerd_devmapper_setup.sh
@@ -44,18 +44,18 @@ sudo systemctl enable --now containerd-devmapper
 # no. of feature arguments
 # Skip zeroing blocks for new volumes.
 sudo dmsetup create contd-thin-pool \
-  --table "0 2097152 thin-pool /dev/loop21 /dev/loop20 512 32768 1 skip_block_zeroing"
+  --table "0 20971520 thin-pool /dev/loop21 /dev/loop20 512 32768 1 skip_block_zeroing"
 
 sudo mkdir -p /etc/containerd/
 if [ -f /etc/containerd/config.toml ]
 then
-  sudo sed -i 's|^\(\[plugins\]\).*|\1\n  \[plugins.devmapper\]\n    pool_name = \"contd-thin-pool\"\n    base_image_size = \"512MB\"|' /etc/containerd/config.toml
+  sudo sed -i 's|^\(\[plugins\]\).*|\1\n  \[plugins.devmapper\]\n    pool_name = \"contd-thin-pool\"\n    base_image_size = \"4096MB\"|' /etc/containerd/config.toml
 else
   cat<<EOT | sudo tee /etc/containerd/config.toml
 [plugins]
   [plugins.devmapper]
     pool_name = "contd-thin-pool"
-    base_image_size = "512MB"
+    base_image_size = "4096MB"
 EOT
 fi
 


### PR DESCRIPTION
base_image_size is effectively the max size of the thinpool snapshot,
and this is static (does not resize).  If you are running containers
with larger individual layers, this will fail. (elastic is a good test
for this).

The thinpool should be 10GB, not 1GB (to align with the .img's defined
earlier in file).

Fixes: #266

Signed-off-by: Eric Ernst <eric.ernst@intel.com>