### PR TITLE
metrics: graph improvements

### DIFF
--- a/metrics/report/report_dockerfile/collectd_scaling.R
+++ b/metrics/report/report_dockerfile/collectd_scaling.R
@@ -657,7 +657,7 @@ interface_drop_line_plot <- ggplot() +
 	labs(colour="") +
 	xlab("seconds") +
 	ylab("drops") +
-	scale_y_continuous(labels=comma, sec.axis=sec_axis(~ ./drop_scale, name="pods")) +
+	scale_y_continuous(breaks=pretty_breaks(), sec.axis=sec_axis(~ ./drop_scale, name="pods", labels=comma)) +
 	ggtitle("interface drops") +
 	theme(legend.position="bottom") +
 	theme(axis.text.x=element_text(angle=90))
@@ -692,7 +692,7 @@ interface_error_line_plot <- ggplot() +
 	labs(colour="") +
 	xlab("seconds") +
 	ylab("errors") +
-	scale_y_continuous(labels=comma, sec.axis=sec_axis(~ ./error_scale, name="pods")) +
+	scale_y_continuous(breaks=pretty_breaks(), sec.axis=sec_axis(~ ./error_scale, name="pods", labels=comma)) +
 	ggtitle("interface errors") +
 	theme(legend.position="bottom") +
 	theme(axis.text.x=element_text(angle=90))

--- a/metrics/report/report_dockerfile/collectd_scaling.R
+++ b/metrics/report/report_dockerfile/collectd_scaling.R
@@ -435,6 +435,7 @@ mem_line_plot <- ggplot() +
 	ylab("System Avail (Gb)") +
 	scale_y_continuous(labels=comma, sec.axis=sec_axis(~ ./mem_scale, name="pods")) +
 	ggtitle("System Memory free") +
+	theme(legend.position="bottom") +
 	theme(axis.text.x=element_text(angle=90))
 
 page1 = grid.arrange(
@@ -473,6 +474,7 @@ cpu_line_plot <- ggplot() +
 	xlab("seconds") +
 	ylab("System CPU Idle (%)") +
 	ggtitle("System CPU usage") +
+	theme(legend.position="bottom") +
 	theme(axis.text.x=element_text(angle=90))
 
 page2 = grid.arrange(
@@ -497,6 +499,7 @@ boot_line_plot <- ggplot() +
 	xlab("pods") +
 	ylab("Boot time (s)") +
 	ggtitle("Pod boot time") +
+	theme(legend.position="bottom") +
 	theme(axis.text.x=element_text(angle=90))
 
 page3 = grid.arrange(
@@ -535,6 +538,7 @@ inode_line_plot <- ggplot() +
 	ylab("inodes free") +
 	scale_y_continuous(labels=comma, sec.axis=sec_axis(~ ./inode_scale, name="pods")) +
 	ggtitle("inodes free") +
+	theme(legend.position="bottom") +
 	theme(axis.text.x=element_text(angle=90))
 
 page4 = grid.arrange(
@@ -577,6 +581,7 @@ interface_packet_line_plot <- ggplot() +
 	ylab("packets") +
 	scale_y_continuous(labels=comma, sec.axis=sec_axis(~ ./ip_scale, name="pods")) +
 	ggtitle("interface packets") +
+	theme(legend.position="bottom") +
 	theme(axis.text.x=element_text(angle=90))
 
 oct_scale = max(c(max(ifoctetdata$tx, na.rm=TRUE),
@@ -609,6 +614,7 @@ interface_octet_line_plot <- ggplot() +
 	ylab("octets") +
 	scale_y_continuous(labels=comma, sec.axis=sec_axis(~ ./oct_scale, name="pods")) +
 	ggtitle("interface octets") +
+	theme(legend.position="bottom") +
 	theme(axis.text.x=element_text(angle=90))
 
 page5 = grid.arrange(
@@ -653,6 +659,7 @@ interface_drop_line_plot <- ggplot() +
 	ylab("drops") +
 	scale_y_continuous(labels=comma, sec.axis=sec_axis(~ ./drop_scale, name="pods")) +
 	ggtitle("interface drops") +
+	theme(legend.position="bottom") +
 	theme(axis.text.x=element_text(angle=90))
 
 # errors are often 0, so providing 1 so we won't scale by infinity
@@ -687,6 +694,7 @@ interface_error_line_plot <- ggplot() +
 	ylab("errors") +
 	scale_y_continuous(labels=comma, sec.axis=sec_axis(~ ./error_scale, name="pods")) +
 	ggtitle("interface errors") +
+	theme(legend.position="bottom") +
 	theme(axis.text.x=element_text(angle=90))
 
 page6 = grid.arrange(

--- a/metrics/report/report_dockerfile/pdf.Rmd
+++ b/metrics/report/report_dockerfile/pdf.Rmd
@@ -8,6 +8,10 @@ author: "Auto generated"
 date: "`r format(Sys.time(), '%d %B, %Y')`"
 output:
   pdf_document:
+# Shrink the page margins so we get bigger/better resolution on the graphs
+# Keep the top and bottom margins reasonable, as we are really interested in
+# gaining 'width', and if we trim the bottom too much, we lose the page numbers.
+geometry: "left=1cm, right=1cm, top=2cm, bottom=2cm"
 urlcolor: blue
 ---
 

--- a/metrics/report/report_dockerfile/tidy_scaling.R
+++ b/metrics/report/report_dockerfile/tidy_scaling.R
@@ -190,13 +190,13 @@ for (currentdir in resultdirs) {
 				"avg_inode"=round(inodetotal/num_pods, 4)
 				)
 			inodestats=rbind(inodestats, local_inodes)
-		}
 
-		# And collect up our rows into our global table of all results
-		# These two tables *should* be the source of all the data we need to
-		# process and plot (apart from the stats....)
-		bootdata=rbind(bootdata, local_bootdata, make.row.names=FALSE)
-		nodedata=rbind(nodedata, local_nodedata, make.row.names=FALSE)
+			# And collect up our rows into our global table of all results
+			# These two tables *should* be the source of all the data we need to
+			# process and plot (apart from the stats....)
+			bootdata=rbind(bootdata, local_bootdata, make.row.names=FALSE)
+			nodedata=rbind(nodedata, local_nodedata, make.row.names=FALSE)
+		}
 	}
 }
 

--- a/metrics/report/report_dockerfile/tidy_scaling.R
+++ b/metrics/report/report_dockerfile/tidy_scaling.R
@@ -229,6 +229,7 @@ mem_line_plot <- ggplot(data=nodedata, aes(n_pods,
 	ylab("System Avail (Gb)") +
 	scale_y_continuous(labels=comma) +
 	ggtitle("System Memory free") +
+	theme(legend.position="bottom") +
 	theme(axis.text.x=element_text(angle=90))
 
 page1 = grid.arrange(
@@ -256,6 +257,7 @@ cpu_line_plot <- ggplot(data=nodedata, aes(n_pods,
 	xlab("pods") +
 	ylab("System CPU Idle (%)") +
 	ggtitle("System CPU usage") +
+	theme(legend.position="bottom") +
 	theme(axis.text.x=element_text(angle=90))
 
 page2 = grid.arrange(
@@ -279,6 +281,7 @@ boot_line_plot <- ggplot() +
 	xlab("pods") +
 	ylab("Boot time (s)") +
 	ggtitle("Pod boot time") +
+	theme(legend.position="bottom") +
 	theme(axis.text.x=element_text(angle=90))
 
 page3 = grid.arrange(
@@ -307,6 +310,7 @@ inode_line_plot <- ggplot(data=nodedata, aes(n_pods,
 	ylab("inodes free") +
 	scale_y_continuous(labels=comma) +
 	ggtitle("inodes free") +
+	theme(legend.position="bottom") +
 	theme(axis.text.x=element_text(angle=90))
 
 page4 = grid.arrange(


### PR DESCRIPTION
A small set of improvements to help graph readability in the report:
- move the legends under the graphs, which allows the graphs to be wider
- reduce the page margins in the pdf, which allows the graphs to be wider still
- improve the lhs y axis for the interface drop/error graphs so the labels look sensible.