### PR TITLE
Using consistent ENV variable for RUNNER

### DIFF
--- a/clr-k8s-examples/README.md
+++ b/clr-k8s-examples/README.md
@@ -38,6 +38,9 @@ This script ensures the following
 script uses the runtime specified in the `RUNNER` environment variable and defaults to `crio`. To use the
 `containerd` runtime, set the `RUNNER` environment variable to `containerd`.
 
+In case of vagrant, if you want to spin up VM's using different environment variable than declared in [`setup_system.sh`],
+specify when performing vagrant up. E.g., `RUNNER=containerd vagrant up`
+
 ### Specify a version of Clear Linux
 
 To specify a particular version of Clear Linux to use, set the CLRK8S_CLR_VER environment variable to the desired

--- a/clr-k8s-examples/create_stack.sh
+++ b/clr-k8s-examples/create_stack.sh
@@ -30,7 +30,8 @@ METALLB_VER="${CLRK8S_METALLB_VER:-v0.8.1}"
 NPD_VER="${CLRK8S_NPD_VER:-v0.6.6}"
 PROMETHEUS_VER="${CLRK8S_PROMETHEUS_VER:-f458e85e5d7675f7bc253072e1b4c8892b51af0f}"
 CNI=${CLRK8S_CNI:-"canal"}
-RUNNER=${CLRK8S_RUNNER:-"crio"}
+if [[ -z "${RUNNER+x}" ]]; then RUNNER="${CLRK8S_RUNNER:-"crio"}"; fi
+
 NFD_VER="${CLRK8S_NFD_VER:-v0.4.0}"
 
 function print_usage_exit() {
@@ -144,10 +145,10 @@ function cni() {
 		FLANNEL_VER=${1:-$FLANNEL_VER}
 		FLANNEL_URL="https://github.com/coreos/flannel"
 		FLANNEL_DIR="0-flannel"
-		
+
 		get_repo "${FLANNEL_URL}" "${FLANNEL_DIR}/overlays/${FLANNEL_VER}"
-        	set_repo_version "${FLANNEL_VER}" "${FLANNEL_DIR}/overlays/${FLANNEL_VER}/flannel"
-        	kubectl apply -k "${FLANNEL_DIR}/overlays/${FLANNEL_VER}"
+		set_repo_version "${FLANNEL_VER}" "${FLANNEL_DIR}/overlays/${FLANNEL_VER}/flannel"
+		kubectl apply -k "${FLANNEL_DIR}/overlays/${FLANNEL_VER}"
 		;;
 	cilium)
 		CILIUM_VER=${1:-$CILIUM_VER}

--- a/clr-k8s-examples/setup_system.sh
+++ b/clr-k8s-examples/setup_system.sh
@@ -11,12 +11,11 @@ HIGH_POD_COUNT=${HIGH_POD_COUNT:-""}
 # set no proxy
 ADD_NO_PROXY=".svc,10.0.0.0/8,192.168.0.0/16"
 ADD_NO_PROXY+=",$(hostname -I | sed 's/[[:space:]]/,/g')"
-: "${RUNNER:=crio}"
+if [[ -z "${RUNNER+x}" ]]; then RUNNER="${CLRK8S_RUNNER:-crio}"; fi
 
 # update os version
 function upate_os_version() {
-	if [[ -n "${CLR_VER}" ]];
-	then
+	if [[ -n "${CLR_VER}" ]]; then
 		sudo swupd repair -m "${CLR_VER}" --picky
 		return
 	fi


### PR DESCRIPTION
Earlier there was confusion between CLRK8S_RUNNER and RUNNER in
setup_system.sh and create_stack.sh script, this patch fixes this
and now the variable can either be RUNNER/CLRK8S_RUNNER.

Signed-off: syed.ahsan.shamim.zaidi@intel.com 
#272 