### PR TITLE
metrics: make pods_per_gb valid JSON

### DIFF
--- a/metrics/scaling/k8s_scale.sh
+++ b/metrics/scaling/k8s_scale.sh
@@ -169,7 +169,7 @@ EOF
 	if [ $n_pods -eq 0 ]; then
 		local pods_per_gb=0
 	else
-		local pods_per_gb=$(bc -l <<< "scale=2; ($total_mem_used/1024) / $n_pods")
+		local pods_per_gb=$(printf "%0f" $(bc -l <<< "scale=2; ($total_mem_used/1024) / $n_pods"))
 	fi
 	local mem_json="$(cat << EOF
 			"memory": {

--- a/metrics/scaling/k8s_scale_nc.sh
+++ b/metrics/scaling/k8s_scale_nc.sh
@@ -195,7 +195,7 @@ EOF
 	if [ $n_pods -eq 0 ]; then
 		local pods_per_gb=0
 	else
-		local pods_per_gb=$(bc -l <<< "scale=2; ($total_mem_used/1024) / $n_pods")
+		local pods_per_gb=$(printf "%0f" $(bc -l <<< "scale=2; ($total_mem_used/1024) / $n_pods"))
 	fi
 	local mem_json="$(cat << EOF
 			"memory": {


### PR DESCRIPTION
Under some circumstances, the pod_per_gb value would come out as <0,
and be generated without any leading 0's (such as `.14` rather than
`0.14`). This is not valid JSON, and would break the report generation
parsing in R.

Use `printf` to force a leading 0 prefix onto the value.

Signed-off-by: Graham Whaley <graham.whaley@intel.com>