### PR TITLE
metrics: improve view for high pod count data

### DIFF
--- a/metrics/report/report_dockerfile/metrics_report.Rmd
+++ b/metrics/report/report_dockerfile/metrics_report.Rmd
@@ -19,8 +19,6 @@ This [test](https://github.com/clearlinux/cloud-native-setup/metrics/scaling/k8s
 measures the system memory 'free' reduction, CPU idle %, free inodes, and pod boot time as
 it launches more and more idle `busybox` pods on a Kubernetes cluster.
 
-> Note: CPU % is measured as a system whole - 100% represents *all* CPUs on the node.
-
 ```{r scaling, echo=FALSE, fig.cap="K8S scaling", results='asis'}
 source('tidy_scaling.R')
 ```


### PR DESCRIPTION
A collection of improvements for viewing larger and noisy data sets:
- If we have a lot of data points (>20), do not plot the geom_points, as they just add noise
- Use a linear model fitting to try and calculate the CPU-per-pod data
- Try to fit a colour palette to the test sets to separate them, if we can