### PR TITLE
Make and rename net server process variables configurable

### DIFF
--- a/metrics/scaling/common.bash
+++ b/metrics/scaling/common.bash
@@ -25,8 +25,8 @@ delete_wait_time=${delete_wait_time:-600}
 settle_time=${settle_time:-5}
 use_api=${use_api:-yes}
 grace=${grace:-30}
-wait_time_proc=20
-sleep_time_proc=2
+proc_wait_time=${proc_wait_time:-20}
+proc_sleep_time=2
 
 declare -a new_pods
 declare -A node_basemem

--- a/metrics/scaling/k8s_scale_net.sh
+++ b/metrics/scaling/k8s_scale_net.sh
@@ -158,7 +158,7 @@ run() {
 
         # Check service exposed
         cmd="kubectl get services $deployment -n default --no-headers=true"
-        waitForProcess "$wait_time_proc" "$sleep_time_proc" "$cmd" "Waiting for service"
+        waitForProcess "$proc_wait_time" "$proc_sleep_time" "$cmd" "Waiting for service"
 
 		IP=$(kubectl get services $deployment -n default --no-headers=true | awk '{printf $3}')
 		end_net=$(date +%s%N)
@@ -166,7 +166,7 @@ run() {
 
 		# service health check
         cmd="curl --noproxy \"*\" http://$IP:8080/healthz"
-        waitForProcess "$wait_time_proc" "$sleep_time_proc" "$cmd" "http server is not ready yet!!"
+        waitForProcess "$proc_wait_time" "$proc_sleep_time" "$cmd" "http server is not ready yet!!"
 
 		RESP=$(curl -s --noproxy "*" http://$IP:8080/echo?msg=curl%20request%20to%20$deployment)
 		local end_time=$(date +%s%N)
@@ -241,6 +241,8 @@ show_vars() {
 	echo -e "\t\tNumber of pods to launch per cycle"
 	echo -e "\twait_time (${wait_time})"
 	echo -e "\t\tSeconds to wait for pods to become ready"
+	echo -e "\tproc_wait_time (${proc_wait_time})"
+	echo -e "\t\tSeconds to wait for net server process to become ready"
 	echo -e "\tdelete_wait_time (${delete_wait_time})"
 	echo -e "\t\tSeconds to wait for all pods to be deleted"
 	echo -e "\tsettle_time (${settle_time})"


### PR DESCRIPTION
Some CNIs takes longer for its related deployments to become ready, that
is why `proc_wait_time` needs to be customized. Now `proc_wait_time` can
be set at execution time and has a default value too for time to pod network test harness.