### PR TITLE
Add the minimun connection time out for `curl` call

### DIFF
--- a/metrics/scaling/k8s_scale_net.sh
+++ b/metrics/scaling/k8s_scale_net.sh
@@ -165,7 +165,7 @@ run() {
 		info "IP: $IP"
 
 		# service health check
-        cmd="curl --noproxy \"*\" http://$IP:8080/healthz"
+        cmd="curl --noproxy \"*\" http://$IP:8080/healthz --connect-timeout 1"
         waitForProcess "$proc_wait_time" "$proc_sleep_time" "$cmd" "http server is not ready yet!!"
 
 		RESP=$(curl -s --noproxy "*" http://$IP:8080/echo?msg=curl%20request%20to%20$deployment)


### PR DESCRIPTION
The time to pod network test harness was hanging when the net server was
not ready due to the `curl` execution because `curl` has its own connection
time out and it can be up to two minutes. Now, such connection time out is set
to one second.