### PR TITLE
Added --force flag to swupd repair command

### DIFF
--- a/clr-k8s-examples/setup_system.sh
+++ b/clr-k8s-examples/setup_system.sh
@@ -16,7 +16,7 @@ if [[ -z "${RUNNER+x}" ]]; then RUNNER="${CLRK8S_RUNNER:-crio}"; fi
 # update os version
 function upate_os_version() {
 	if [[ -n "${CLR_VER}" ]]; then
-		sudo swupd repair -m "${CLR_VER}" --picky
+		sudo swupd repair -m "${CLR_VER}" --picky --force
 		return
 	fi
 	sudo swupd update


### PR DESCRIPTION
Running setup_system.sh on a system setting the OS version to keep setup_system from upgrading the OS causes an error because a package has been removed. Need to add the --force flag to the
sudo swupd repair -m "${CLR_VER}" --picky command

Closes issue #297