### PR TITLE
rook: allow multiple mons per node

### DIFF
--- a/clr-k8s-examples/7-rook/overlays/v1.0.3/patch_cephcluster.yaml
+++ b/clr-k8s-examples/7-rook/overlays/v1.0.3/patch_cephcluster.yaml
@@ -4,6 +4,17 @@ metadata:
   name: rook-ceph
   namespace: rook-ceph
 spec:
+  mon:
+    allowMultiplePerNode: true
   storage:
     directories:
      - path: /var/lib/rook
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: replicapool
+  namespace: rook-ceph
+spec:
+  replicated:
+    size: 1

--- a/clr-k8s-examples/7-rook/overlays/v1.1.0/patch_cephcluster.yaml
+++ b/clr-k8s-examples/7-rook/overlays/v1.1.0/patch_cephcluster.yaml
@@ -4,6 +4,17 @@ metadata:
   name: rook-ceph
   namespace: rook-ceph
 spec:
+  mon:
+    allowMultiplePerNode: true
   storage:
     directories:
      - path: /var/lib/rook
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: replicapool
+  namespace: rook-ceph
+spec:
+  replicated:
+    size: 1

--- a/clr-k8s-examples/7-rook/overlays/v1.1.1/patch_cephcluster.yaml
+++ b/clr-k8s-examples/7-rook/overlays/v1.1.1/patch_cephcluster.yaml
@@ -4,6 +4,17 @@ metadata:
   name: rook-ceph
   namespace: rook-ceph
 spec:
+  mon:
+    allowMultiplePerNode: true
   storage:
     directories:
      - path: /var/lib/rook
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: replicapool
+  namespace: rook-ceph
+spec:
+  replicated:
+    size: 1

--- a/clr-k8s-examples/7-rook/overlays/v1.1.7/patch_cephcluster.yaml
+++ b/clr-k8s-examples/7-rook/overlays/v1.1.7/patch_cephcluster.yaml
@@ -4,6 +4,17 @@ metadata:
   name: rook-ceph
   namespace: rook-ceph
 spec:
+  mon:
+    allowMultiplePerNode: true
   storage:
     directories:
      - path: /var/lib/rook
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: replicapool
+  namespace: rook-ceph
+spec:
+  replicated:
+    size: 1

--- a/clr-k8s-examples/README.md
+++ b/clr-k8s-examples/README.md
@@ -162,3 +162,12 @@ Grafana is available at this URL http://localhost:3000 . Default credentials are
 ## Cleaning up the cluster (Hard reset to a clean state)
 
 Run `reset_stack.sh` on all the nodes
+
+## Caveats
+
+### Rook
+* Rook is provisioned by default to allow multiple monitors on the same node if we do not have enough worker nodes.(Rook looks to spin up 3 monitor pods). If you have sufficient number of workers, the monitor pods automatically balanced across all of them.
+* To aid a single node setup, the default replica pool replicas is being set to 1 against the default of 3. If the user of this tool is using this in a production environment, we strongly recommend that the user create a ceph pool that is tailored to their use-case.
+
+#### Downside
+The downside of this setup will be when you start with less than optimal number of nodes and then add more. The monitor pods do not re-balance automatically and you might want to remove `allowMultiplePerNode` line from `patch_cephcluster.yaml` and re-deploy rook.


### PR DESCRIPTION
On a single node setup, rook will fail to get stuck waiting on OSDs as
monitors by default have an anti-affinity rule that prevents multiple
monitors to land on a single node. This will also be an issue if you are
using this setup of < 4 nodes (1 master and 3 workers) as the master has
the NoSchedule taint. This patch allows multiple monitors on a single
node. When multiple nodes are present, the monitor pods are
automatically distributed.

Downside: When the setup is started with a single node and then more
nodes are added, the monitor pods *DO NOT* automatically re-balance.

Fixes: #306

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>