### PR TITLE
Update vfioveth CNI to add VF device id as alias

### DIFF
--- a/clr-k8s-examples/9-multi-network/cni/vfioveth
+++ b/clr-k8s-examples/9-multi-network/cni/vfioveth
@@ -38,7 +38,7 @@ add_pair_ns() {
 	ln -sfT $CNI_NETNS /var/run/netns/$CNI_CONTAINERID
 
 	ip netns exec $CNI_CONTAINERID ip link add $CNI_IFNAME type veth peer name $peer
-	ip netns exec $CNI_CONTAINERID ip link set $CNI_IFNAME addr $mac up
+	ip netns exec $CNI_CONTAINERID ip link set $CNI_IFNAME addr $mac up alias $vfpci
 	ip netns exec $CNI_CONTAINERID ip link set $peer up
 	ip netns exec $CNI_CONTAINERID ip addr add $ip dev $CNI_IFNAME
 }


### PR DESCRIPTION
```
5: s1u-vdev@s1u: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default qlen 1000
    link/ether d2:8e:b5:97:4b:de brd ff:ff:ff:ff:ff:ff
6: s1u@s1u-vdev: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default qlen 1000
    link/ether ee:b6:c7:9a:0c:a6 brd ff:ff:ff:ff:ff:ff
    alias 0000:04:10.4
```