### PR TITLE
metrics: Use a specific version of rocker/tidyverse

### DIFF
--- a/metrics/report/report_dockerfile/Dockerfile
+++ b/metrics/report/report_dockerfile/Dockerfile
@@ -13,10 +13,10 @@
 # We would have used the 'verse' base, that already has some of the docs processing
 # installed, but I could not figure out how to add in the extra bits we needed to
 # the lite tex version is uses.
-FROM rocker/tidyverse:latest
+FROM rocker/tidyverse:3.6.0
 
 # Version of the Dockerfile
-LABEL DOCKERFILE_VERSION="1.0"
+LABEL DOCKERFILE_VERSION="1.1"
 
 # Without this some of the package installs stop to try and ask questions...
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
This PR uses a specific version of rocker/tidyverse as the latest version
does not have the latex-xcolor package which makes impossible to create
the metrics report.

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>