### PR TITLE
Updated metrics github location

### DIFF
--- a/clr-k8s-examples/create_stack.sh
+++ b/clr-k8s-examples/create_stack.sh
@@ -170,7 +170,7 @@ function cni() {
 
 function metrics() {
 	METRICS_VER="${1:-$METRICS_VER}"
-	METRICS_URL="https://github.com/kubernetes-incubator/metrics-server.git"
+	METRICS_URL="https://github.com/kubernetes-sigs/metrics-server.git"
 	METRICS_DIR="1-core-metrics"
 	get_repo "${METRICS_URL}" "${METRICS_DIR}/overlays/${METRICS_VER}"
 	set_repo_version "${METRICS_VER}" "${METRICS_DIR}/overlays/${METRICS_VER}/metrics-server"


### PR DESCRIPTION
The metrics-server package has moved out of the kubernetes incubator
github location and is now in the sigs location.

Closes issue #322 

Signed-off-by: Craig Sterrett <craig.Sterrett@intel.com>