### PR TITLE
setup_system: use local admin path for proxy.conf

### DIFF
--- a/clr-k8s-examples/setup_system.sh
+++ b/clr-k8s-examples/setup_system.sh
@@ -161,7 +161,8 @@ function setup_proxy() {
 			echo "Warning, failed to find /etc/profile.d/proxy.sh to edit no_proxy line"
 		fi
 
-		cat <<EOF | sudo bash -c "cat > /usr/lib/systemd/system.conf.d/proxy.conf"
+		sudo mkdir -p /etc/systemd/system.conf.d
+		cat <<EOF | sudo bash -c "cat > /etc/systemd/system.conf.d/proxy.conf"
 [Manager]
 DefaultEnvironment="HTTP_PROXY=${http_proxy}"
 DefaultEnvironment="HTTPS_PROXY=${https_proxy}"


### PR DESCRIPTION
Currently the system.conf.d/proxy.conf file is saved at /usr/lib
which is the vendor path, and can be dropped by
"swupd repair --picky --force".

This PR creates the local administrator /etc/systemd/system.conf.d
directory and store the proxy.conf inside.