### PR TITLE
accommodate upstream libvirt boxes changes in a forward and backward way

### DIFF
--- a/clr-k8s-examples/Vagrantfile
+++ b/clr-k8s-examples/Vagrantfile
@@ -76,6 +76,7 @@ Vagrant.configure("2") do |config|
         lv.loader = $loader
         lv.cpus = $cpus
         lv.memory = $memory
+        lv.machine_virtual_size = 40
         (1..$disks).each do |d|
           lv.storage :file, :device => "hd#{$driveletters[d]}", :path => "disk-#{$disk_prefix}-#{vm_name}-#{d}.disk", :size => $disk_size, :type => "raw"
         end


### PR DESCRIPTION
Hi all, 

per https://github.com/AntonioMeireles/ClearLinux-packer/issues/24 the
ClearLinux libvirt boxes default size was lowered from the previous 40G
to a more manageable 5G, having the user the ability to, at box
instantiation, to increase that value to whatever is adequate.

In order to avoid surprises in this side the Vagrantfile was modded to
have hardcoded the previous default value.

This change is forward and backward compatible as it will just be
ignored when using older boxes ( since the 'new' root volume size just
the same as original one) and will resize the box to the expected 40G in
newer ones.

Please do note that albeit code is committed, i'm not yet build new boxes with
new code - as i think it would be handy to have this merged this side first to avoid breakages

All the best!