### PR TITLE
Remove static cpu from kubeadm.yaml

### DIFF
--- a/clr-k8s-examples/kubeadm.yaml
+++ b/clr-k8s-examples/kubeadm.yaml
@@ -4,8 +4,6 @@ kind: InitConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 cgroupDriver: systemd
-# Allowing for CPU pinning and isolation in case of guaranteed QoS class
-cpuManagerPolicy: static
 systemReserved:
   cpu: 500m
   memory: 256M


### PR DESCRIPTION
Removing static cpu pinning due to confusion and complications it causes with disabling/enabling cores.